### PR TITLE
MODCXEKB-80: Move parameter validators from mod-kb-ebsco-java

### DIFF
--- a/src/main/java/org/folio/holdingsiq/service/impl/ConfigurationServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/ConfigurationServiceImpl.java
@@ -83,8 +83,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
     if (!isConfigurationParametersValid(configuration, errors)) {
       return CompletableFuture.completedFuture(errors);
     }
-    return new HoldingsIQServiceImpl(configuration.getCustomerId(), configuration.getApiKey(),
-      configuration.getUrl(), vertxContext.owner())
+    return new HoldingsIQServiceImpl(configuration, vertxContext.owner())
       .verifyCredentials()
       .thenCompose(o -> CompletableFuture.completedFuture(Collections.<ConfigurationError>emptyList()))
       .exceptionally(e -> Collections.singletonList(new ConfigurationError("KB API Credentials are invalid")));

--- a/src/main/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.concurrent.CompletableFuture;
 
 import io.vertx.core.Vertx;
 
+import org.folio.holdingsiq.model.Configuration;
 import org.folio.holdingsiq.model.Proxies;
 import org.folio.holdingsiq.model.RootProxyCustomLabels;
 import org.folio.holdingsiq.service.HoldingsIQService;
@@ -14,8 +15,8 @@ public class HoldingsIQServiceImpl implements HoldingsIQService {
 
   private HoldingsRequestHelper holdingsRequestHelper;
 
-  public HoldingsIQServiceImpl(String customerId, String apiKey, String baseURI, Vertx vertx) {
-    holdingsRequestHelper = new HoldingsRequestHelper(customerId, apiKey, baseURI, vertx);
+  public HoldingsIQServiceImpl(Configuration config, Vertx vertx) {
+    holdingsRequestHelper = new HoldingsRequestHelper(config, vertx);
   }
 
   @Override

--- a/src/main/java/org/folio/holdingsiq/service/impl/HoldingsRequestHelper.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/HoldingsRequestHelper.java
@@ -13,6 +13,7 @@ import io.vertx.core.json.Json;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
+import org.folio.holdingsiq.model.Configuration;
 import org.folio.holdingsiq.service.exception.ResourceNotFoundException;
 import org.folio.holdingsiq.service.exception.ResultsProcessingException;
 import org.folio.holdingsiq.service.exception.ServiceResponseException;
@@ -45,10 +46,10 @@ public class HoldingsRequestHelper {
 
   private Vertx vertx;
 
-  public HoldingsRequestHelper(String customerId, String apiKey, String baseURI, Vertx vertx) {
-    this.customerId = customerId;
-    this.apiKey = apiKey;
-    this.baseURI = baseURI;
+  public HoldingsRequestHelper(Configuration config, Vertx vertx) {
+    this.customerId = config.getCustomerId();
+    this.apiKey = config.getApiKey();
+    this.baseURI = config.getUrl();
     this.vertx = vertx;
   }
 

--- a/src/main/java/org/folio/holdingsiq/service/impl/PackagesHoldingsIQServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/PackagesHoldingsIQServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletionStage;
 
 import io.vertx.core.Vertx;
 
+import org.folio.holdingsiq.model.Configuration;
 import org.folio.holdingsiq.model.PackageByIdData;
 import org.folio.holdingsiq.model.PackageCreated;
 import org.folio.holdingsiq.model.PackageId;
@@ -23,8 +24,8 @@ public class PackagesHoldingsIQServiceImpl implements PackagesHoldingsIQService 
 
   private HoldingsRequestHelper holdingsRequestHelper;
 
-  public PackagesHoldingsIQServiceImpl(String customerId, String apiKey, String baseURI, Vertx vertx) {
-    holdingsRequestHelper = new HoldingsRequestHelper(customerId, apiKey, baseURI, vertx);
+  public PackagesHoldingsIQServiceImpl(Configuration config, Vertx vertx) {
+    holdingsRequestHelper = new HoldingsRequestHelper(config, vertx);
   }
 
   @Override

--- a/src/main/java/org/folio/holdingsiq/service/impl/ProviderHoldingsIQServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/ProviderHoldingsIQServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.concurrent.CompletableFuture;
 
 import io.vertx.core.Vertx;
 
+import org.folio.holdingsiq.model.Configuration;
 import org.folio.holdingsiq.model.Sort;
 import org.folio.holdingsiq.model.VendorById;
 import org.folio.holdingsiq.model.VendorPut;
@@ -20,9 +21,14 @@ public class ProviderHoldingsIQServiceImpl implements ProviderHoldingsIQService 
   private HoldingsIQService holdingsIQService;
   private HoldingsRequestHelper holdingsRequestHelper;
 
-  public ProviderHoldingsIQServiceImpl(String customerId, String apiKey, String baseURI, Vertx vertx, HoldingsIQService holdingsIQService) {
-    holdingsRequestHelper = new HoldingsRequestHelper(customerId, apiKey, baseURI, vertx);
+  public ProviderHoldingsIQServiceImpl(Configuration config, Vertx vertx, HoldingsIQService holdingsIQService) {
+    holdingsRequestHelper = new HoldingsRequestHelper(config, vertx);
     this.holdingsIQService = holdingsIQService;
+  }
+
+  public ProviderHoldingsIQServiceImpl(Configuration config, Vertx vertx) {
+    holdingsRequestHelper = new HoldingsRequestHelper(config, vertx);
+    this.holdingsIQService = new HoldingsIQServiceImpl(config, vertx);
   }
 
   @Override

--- a/src/main/java/org/folio/holdingsiq/service/impl/ResourcesHoldingsIQServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/ResourcesHoldingsIQServiceImpl.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletionStage;
 
 import io.vertx.core.Vertx;
 
+import org.folio.holdingsiq.model.Configuration;
 import org.folio.holdingsiq.model.ResourceDeletePayload;
 import org.folio.holdingsiq.model.ResourceId;
 import org.folio.holdingsiq.model.ResourcePut;
@@ -23,8 +24,8 @@ public class ResourcesHoldingsIQServiceImpl implements ResourcesHoldingsIQServic
   private static final String RESOURCE_ENDPOINT_FORMAT = "vendors/%s/packages/%s/titles/%s";
   private HoldingsRequestHelper holdingsRequestHelper;
 
-  public ResourcesHoldingsIQServiceImpl(String customerId, String apiKey, String baseURI, Vertx vertx) {
-    holdingsRequestHelper = new HoldingsRequestHelper(customerId, apiKey, baseURI, vertx);
+  public ResourcesHoldingsIQServiceImpl(Configuration config, Vertx vertx) {
+    holdingsRequestHelper = new HoldingsRequestHelper(config, vertx);
   }
 
   @Override

--- a/src/main/java/org/folio/holdingsiq/service/impl/TitlesHoldingsIQServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/TitlesHoldingsIQServiceImpl.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletableFuture;
 
 import io.vertx.core.Vertx;
 
+import org.folio.holdingsiq.model.Configuration;
 import org.folio.holdingsiq.model.FilterQuery;
 import org.folio.holdingsiq.model.PackageId;
 import org.folio.holdingsiq.model.Sort;
@@ -25,8 +26,8 @@ public class TitlesHoldingsIQServiceImpl implements TitlesHoldingsIQService {
 
   private HoldingsRequestHelper holdingsRequestHelper;
 
-  public TitlesHoldingsIQServiceImpl(String customerId, String apiKey, String baseURI, Vertx vertx) {
-    holdingsRequestHelper = new HoldingsRequestHelper(customerId, apiKey, baseURI, vertx);
+  public TitlesHoldingsIQServiceImpl(Configuration config, Vertx vertx) {
+    holdingsRequestHelper = new HoldingsRequestHelper(config, vertx);
   }
 
   @Override

--- a/src/main/java/org/folio/holdingsiq/service/impl/urlbuilder/PackagesFilterableUrlBuilder.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/urlbuilder/PackagesFilterableUrlBuilder.java
@@ -2,21 +2,12 @@ package org.folio.holdingsiq.service.impl.urlbuilder;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.StringUtils;
 
 import org.folio.holdingsiq.model.Sort;
 
 public class PackagesFilterableUrlBuilder {
-
-  private static final Map<String, String> FILTER_SELECTED_MAPPING =
-    ImmutableMap.of(
-      "true", "selected",
-      "false", "notselected",
-      "ebsco", "orderedthroughebsco"
-    );
 
   private String filterSelected;
   private String filterType;
@@ -57,7 +48,7 @@ public class PackagesFilterableUrlBuilder {
 
   public String build(){
 
-    String selection = FILTER_SELECTED_MAPPING.getOrDefault(filterSelected, "all");
+    String selection = StringUtils.defaultIfEmpty(filterSelected, "all");
     String contentType = StringUtils.defaultIfEmpty(filterType, "all");
     List<String> parameters = new ArrayList<>();
 

--- a/src/main/java/org/folio/holdingsiq/service/impl/urlbuilder/TitlesFilterableUrlBuilder.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/urlbuilder/TitlesFilterableUrlBuilder.java
@@ -2,9 +2,7 @@ package org.folio.holdingsiq.service.impl.urlbuilder;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.StringUtils;
 
 import org.folio.holdingsiq.model.FilterQuery;
@@ -12,13 +10,6 @@ import org.folio.holdingsiq.model.Sort;
 
 
 public class TitlesFilterableUrlBuilder {
-
-  private static final Map<String, String> FILTER_SELECTED_MAPPING =
-    ImmutableMap.of(
-      "true", "selected",
-      "false", "notselected",
-      "ebsco", "orderedthroughebsco"
-    );
   private static final String SEARCHFIELD_TITLENAME = "titlename";
   private static final String SEARCHFIELD_ISXN = "isxn";
   private static final String SEARCHFIELD_PUBLISHER = "publisher";
@@ -68,7 +59,7 @@ public class TitlesFilterableUrlBuilder {
       searchField = SEARCHFIELD_TITLENAME;
     }
 
-    String selection = FILTER_SELECTED_MAPPING.getOrDefault(filterQuery.getSelected(), "all");
+    String selection = StringUtils.defaultString(filterQuery.getSelected(), "all");
 
     String resourceType = StringUtils.defaultString(filterQuery.getType(), "all");
 

--- a/src/main/java/org/folio/holdingsiq/service/validator/PackageParametersValidator.java
+++ b/src/main/java/org/folio/holdingsiq/service/validator/PackageParametersValidator.java
@@ -1,0 +1,32 @@
+package org.folio.holdingsiq.service.validator;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import javax.validation.ValidationException;
+
+import org.folio.holdingsiq.model.Sort;
+
+public class PackageParametersValidator {
+
+  private static final List<String> FILTER_SELECTED_VALUES = Arrays.asList("all", "selected", "notselected" ,"orderedthroughebsco");
+  private static final List<String> FILTER_TYPE_VALUES = Arrays.asList("all", "aggregatedfulltext", "abstractandindex", "ebook", "ejournal", "print", "unknown", "onlinereference");
+
+  public void validate(String filterSelected, String filterType,
+    String sort, String query) {
+
+    if (!Sort.contains(sort.toUpperCase())){
+      throw new ValidationException("Invalid Query Parameter for sort");
+    }
+    if ("".equals(query)) {
+      throw new ValidationException("Search parameter cannot be empty");
+    }
+    if(Objects.nonNull(filterType) &&  !FILTER_TYPE_VALUES.contains(filterType)){
+      throw new ValidationException("Invalid Query Parameter for filter[type]");
+    }
+    if (Objects.nonNull(filterSelected) && !FILTER_SELECTED_VALUES.contains(filterSelected)){
+      throw new ValidationException("Invalid Query Parameter for filter[selected]");
+    }
+  }
+}

--- a/src/main/java/org/folio/holdingsiq/service/validator/TitleParametersValidator.java
+++ b/src/main/java/org/folio/holdingsiq/service/validator/TitleParametersValidator.java
@@ -1,0 +1,68 @@
+package org.folio.holdingsiq.service.validator;
+
+import static java.util.Objects.nonNull;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import javax.validation.ValidationException;
+
+import org.folio.holdingsiq.model.FilterQuery;
+import org.folio.holdingsiq.model.Sort;
+
+public class TitleParametersValidator {
+
+  private static final List<String> FILTER_SELECTED_VALUES = Arrays.asList("all", "selected", "notselected" ,"orderedthroughebsco");
+  private static final List<String> FILTER_TYPE_VALUES = Arrays.asList("audiobook", "book", "bookseries", "database",
+    "journal", "newsletter", "newspaper", "proceedings", "report", "streamingaudio", "streamingvideo",
+    "thesisdissertation", "website", "unspecified");
+
+
+  /**
+   * @throws ValidationException if validation fails
+   */
+  public void validate(FilterQuery filterQuery, String sort) {
+    Boolean allowNullFilters = false;
+    validateFilter(filterQuery, allowNullFilters);
+    validateSort(sort);
+  }
+
+  public void validate(FilterQuery filterQuery, String sort, Boolean allowNullFilters) {
+    validateFilter(filterQuery, allowNullFilters);
+    validateSort(sort);
+  }
+
+  private void validateFilter(FilterQuery fq, Boolean allowNullFilters) {
+    List<String> searchParameters = Arrays.asList(fq.getName(), fq.getIsxn(), fq.getSubject(),
+      fq.getPublisher());
+
+    long nonNullFilters = searchParameters.stream()
+      .filter(Objects::nonNull)
+      .count();
+    if(nonNullFilters > 1){
+      throw new ValidationException("Conflicting filter parameters");
+    }
+    if((nonNullFilters < 1)&&(!allowNullFilters)){
+      throw new ValidationException("All of filter[name], filter[isxn], filter[subject] and filter[publisher] cannot be missing.");
+    }
+    if(searchParameters.stream()
+      .anyMatch(""::equals)){
+      throw new ValidationException("Value of required parameter filter[name], filter[isxn], filter[subject] or filter[publisher] is missing.");
+    }
+    if (nonNull(fq.getSelected()) && !FILTER_SELECTED_VALUES.contains(fq.getSelected())){
+      throw new ValidationException("Invalid Query Parameter for filter[selected]");
+    }
+    if (nonNull(fq.getType()) && !FILTER_TYPE_VALUES.contains(fq.getType())){
+      throw new ValidationException("Invalid Query Parameter for filter[type]");
+    }
+  }
+
+  private void validateSort(String sort) {
+    if (!Sort.contains(sort.toUpperCase())){
+      throw new ValidationException("Invalid sort parameter");
+    }
+  }
+
+}
+

--- a/src/test/java/org/folio/holdingsiq/service/builder/PackagesFilterableUrlBuilderTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/builder/PackagesFilterableUrlBuilderTest.java
@@ -11,7 +11,7 @@ public class PackagesFilterableUrlBuilderTest {
   @Test
   public void shouldBuildUrlWithFilterSelectedTrue() {
     String url = new PackagesFilterableUrlBuilder()
-      .filterSelected("true")
+      .filterSelected("selected")
       .sort(Sort.NAME)
       .build();
     assertEquals("selection=selected&contenttype=all&search=&offset=1&count=25&orderby=packagename", url);
@@ -28,7 +28,7 @@ public class PackagesFilterableUrlBuilderTest {
   @Test
   public void shouldBuildUrlWithFilterSelectedEBSCO() {
     String url = new PackagesFilterableUrlBuilder()
-      .filterSelected("ebsco")
+      .filterSelected("orderedthroughebsco")
       .sort(Sort.NAME)
       .build();
     assertEquals("selection=orderedthroughebsco&contenttype=all&search=&offset=1&count=25&orderby=packagename", url);

--- a/src/test/java/org/folio/holdingsiq/service/builder/TitlesFilterableUrlBuilderTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/builder/TitlesFilterableUrlBuilderTest.java
@@ -52,7 +52,7 @@ public class TitlesFilterableUrlBuilderTest {
   @Test
   public void shouldBuildUrlForFilterBySelectedStatus() {
     String url = new TitlesFilterableUrlBuilder()
-      .filter(fqb.name("news").type("book").selected("true").build())
+      .filter(fqb.name("news").type("book").selected("selected").build())
       .sort(Sort.RELEVANCE)
       .build();
     assertEquals("searchfield=titlename&selection=selected&resourcetype=book&searchtype=advanced&search=news" +

--- a/src/test/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceTestConfig.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceTestConfig.java
@@ -1,6 +1,33 @@
 package org.folio.holdingsiq.service.impl;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.holdingsiq.model.Configuration;
+import org.folio.holdingsiq.model.FilterQuery;
+import org.folio.holdingsiq.model.PackageCreated;
+import org.folio.holdingsiq.model.PackageId;
+import org.folio.holdingsiq.model.PackagePost;
+import org.folio.holdingsiq.model.ResourceId;
+import org.folio.holdingsiq.model.ResourcePut;
+import org.folio.holdingsiq.model.RootProxyCustomLabels;
+import org.folio.holdingsiq.model.TitleCreated;
+import org.folio.holdingsiq.model.TitlePost;
+import org.folio.holdingsiq.model.Titles;
+import org.folio.holdingsiq.model.VendorPut;
+import org.folio.holdingsiq.service.HoldingsIQService;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
@@ -10,18 +37,6 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.json.Json;
-import org.folio.holdingsiq.model.*;
-import org.folio.holdingsiq.service.HoldingsIQService;
-import org.mockito.ArgumentCaptor;
-import org.mockito.stubbing.Answer;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.concurrent.CompletableFuture;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
 
 public class HoldingsIQServiceTestConfig {
   protected static final String STUB_CUSTOMER_ID = "TEST_CUSTOMER_ID";
@@ -33,6 +48,7 @@ public class HoldingsIQServiceTestConfig {
   protected static final Long PACKAGE_ID = 2222L;
   protected static final Long TITLE_ID = 3333L;
   protected static final Long VENDOR_ID = 5555L;
+  protected static final Configuration CONFIGURATION = Configuration.builder().customerId(STUB_CUSTOMER_ID).apiKey(STUB_API_KEY).url(STUB_BASE_URL).build();
 
   protected Vertx mockVertx = mock(Vertx.class);
   protected HttpClient mockClient = mock(HttpClient.class);
@@ -40,7 +56,7 @@ public class HoldingsIQServiceTestConfig {
   protected HttpClientResponse mockResponse = mock(HttpClientResponse.class);
   protected Buffer mockResponseBody = mock(Buffer.class);
   protected MultiMap stubHeaderMap = new CaseInsensitiveHeaders();
-  protected HoldingsIQService service = new HoldingsIQServiceImpl(STUB_CUSTOMER_ID, STUB_API_KEY, STUB_BASE_URL, mockVertx);
+  protected HoldingsIQService service = new HoldingsIQServiceImpl(CONFIGURATION, mockVertx);
   protected ArgumentCaptor<String> url = ArgumentCaptor.forClass(String.class);
 
   protected ObjectMapper savedPrettyMapper;

--- a/src/test/java/org/folio/holdingsiq/service/impl/PackagesHoldingsIQServiceImplTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/PackagesHoldingsIQServiceImplTest.java
@@ -25,8 +25,7 @@ import static org.mockito.Mockito.when;
 public class PackagesHoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig {
 
   private PackagesHoldingsIQService packagesHoldingsIQService =
-    new PackagesHoldingsIQServiceImpl(HoldingsIQServiceImplTest.STUB_CUSTOMER_ID,
-      HoldingsIQServiceImplTest.STUB_API_KEY, HoldingsIQServiceImplTest.STUB_BASE_URL, mockVertx);
+    new PackagesHoldingsIQServiceImpl(HoldingsIQServiceImplTest.CONFIGURATION, mockVertx);
 
   @Before
   public void setUp() throws IOException {
@@ -41,7 +40,7 @@ public class PackagesHoldingsIQServiceImplTest extends HoldingsIQServiceTestConf
   @Test
   public void testRetrievePackages() {
     mockResponse(mockResponseBody, mockResponse, "{}", HttpStatus.SC_OK);
-    CompletableFuture<Packages> completableFuture = packagesHoldingsIQService.retrievePackages("ebsco",
+    CompletableFuture<Packages> completableFuture = packagesHoldingsIQService.retrievePackages("orderedthroughebsco",
       "filterType", VENDOR_ID, "Query", PAGE_FOR_PARAM, COUNT_FOR_PARAM, Sort.NAME);
 
     assertTrue(isCompletedNormally(completableFuture));

--- a/src/test/java/org/folio/holdingsiq/service/impl/ProviderHoldingsIQServiceImplTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/ProviderHoldingsIQServiceImplTest.java
@@ -23,8 +23,7 @@ import static org.mockito.Mockito.when;
 public class ProviderHoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig {
 
   private ProviderHoldingsIQServiceImpl providerHoldingsIQService =
-    new ProviderHoldingsIQServiceImpl(HoldingsIQServiceImplTest.STUB_CUSTOMER_ID,
-      HoldingsIQServiceImplTest.STUB_API_KEY, HoldingsIQServiceImplTest.STUB_BASE_URL, mockVertx, service);
+    new ProviderHoldingsIQServiceImpl(HoldingsIQServiceImplTest.CONFIGURATION, mockVertx, service);
 
   @Before
   public void setUp() throws IOException {

--- a/src/test/java/org/folio/holdingsiq/service/impl/ResourcesHoldingsIQServiceImplTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/ResourcesHoldingsIQServiceImplTest.java
@@ -19,8 +19,7 @@ import static org.mockito.Mockito.verify;
 public class ResourcesHoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig {
 
   private ResourcesHoldingsIQService resourcesHoldingsIQService =
-    new ResourcesHoldingsIQServiceImpl(HoldingsIQServiceImplTest.STUB_CUSTOMER_ID,
-      HoldingsIQServiceImplTest.STUB_API_KEY, HoldingsIQServiceImplTest.STUB_BASE_URL, mockVertx);
+    new ResourcesHoldingsIQServiceImpl(HoldingsIQServiceImplTest.CONFIGURATION, mockVertx);
 
   @Before
   public void setUp() throws IOException {

--- a/src/test/java/org/folio/holdingsiq/service/impl/TitlesHoldingsIQServiceImplTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/TitlesHoldingsIQServiceImplTest.java
@@ -24,8 +24,7 @@ import static org.mockito.Mockito.when;
 public class TitlesHoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig {
 
   private TitlesHoldingsIQService titlesHoldingsIQService =
-    new TitlesHoldingsIQServiceImpl(HoldingsIQServiceImplTest.STUB_CUSTOMER_ID,
-      HoldingsIQServiceImplTest.STUB_API_KEY, HoldingsIQServiceImplTest.STUB_BASE_URL, mockVertx);
+    new TitlesHoldingsIQServiceImpl(HoldingsIQServiceImplTest.CONFIGURATION, mockVertx);
 
   @Before
   public void setUp() throws IOException {

--- a/src/test/java/org/folio/holdingsiq/service/validator/PackageParametersValidatorTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/validator/PackageParametersValidatorTest.java
@@ -1,0 +1,35 @@
+package org.folio.holdingsiq.service.validator;
+
+import javax.validation.ValidationException;
+import org.junit.Test;
+
+public class PackageParametersValidatorTest {
+
+  private final PackageParametersValidator validator = new PackageParametersValidator();
+
+  @Test
+  public void shouldNotThrowExceptionWhenParametersAreValid() {
+    validator.validate(null, null, "relevance", "query");
+  }
+
+  @Test(expected = ValidationException.class)
+  public void shouldThrowExceptionWhenFilterSelectedIsInvalid() {
+    validator.validate("notall", null, "relevance", "query");
+  }
+
+  @Test(expected = ValidationException.class)
+  public void shouldThrowExceptionWhenFilterTypeIsInvalid() {
+    validator.validate("selected", "notall", "relevance", "query");
+  }
+
+  @Test(expected = ValidationException.class)
+  public void shouldThrowExceptionWhenSortIsInvalid() {
+    validator.validate("selected", "all", "abc", "query");
+  }
+
+  @Test(expected = ValidationException.class)
+  public void shouldThrowExceptionWhenSearchQueryIsEmpty() {
+    validator.validate("selected", "all", "abc", "");
+  }
+
+}

--- a/src/test/java/org/folio/holdingsiq/service/validator/TitleParametersValidatorTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/validator/TitleParametersValidatorTest.java
@@ -1,0 +1,74 @@
+package org.folio.holdingsiq.service.validator;
+
+import javax.validation.ValidationException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.folio.holdingsiq.model.FilterQuery;
+
+public class TitleParametersValidatorTest {
+
+  private final TitleParametersValidator validator = new TitleParametersValidator();
+  private FilterQuery.FilterQueryBuilder fqb;
+
+
+  @Before
+  public void setUp() {
+    fqb = FilterQuery.builder();
+  }
+
+  @Test
+  public void shouldNotThrowExceptionWhenParametersAreValid() {
+    validator.validate(fqb.selected("selected").type("book").name("ebsco").build(), "relevance");
+  }
+
+  @Test
+  public void shouldNotThrowExceptionWhenNoFilterParametersAndAllowNullTrue() {
+    validator.validate(fqb
+      .selected(null).type(null)
+      .name(null).isxn(null).subject(null)
+      .publisher(null).build(), "relevance", true);
+  }
+
+  @Test(expected = ValidationException.class)
+  public void shouldThrowExceptionWhenSelectedParameterIsInvalid() {
+    validator.validate(fqb.selected("doNotEnter").type("book").name("ebsco").build(), "relevance");
+  }
+
+  @Test(expected = ValidationException.class)
+  public void shouldThrowExceptionWhenTypeParameterIsInvalid() {
+    validator.validate(fqb.selected("selected").type("doNotEnter").name("ebsco").build(), "relevance");
+  }
+
+  @Test(expected = ValidationException.class)
+  public void shouldThrowExceptionWhenThereAreConflictingParameters() {
+    validator.validate(fqb.selected("selected").type("book").name("ebsco").subject("history").build(), "relevance");
+  }
+
+  /* One of filter[name], filter[isxn], filter[subject] or filter[publisher] is required */
+  @Test(expected = ValidationException.class)
+  public void shouldThrowExceptionWhenAtLeastOneRequiredFilterParametersIsNotProvided() {
+    validator.validate(fqb.selected("selected").type("book").build(), null);
+  }
+
+  @Test(expected = ValidationException.class)
+  public void shouldThrowExceptionWhenFilterNameParameterIsEmpty() {
+    validator.validate(fqb.selected("selected").type("book").name("").build(), "relevance");
+  }
+
+  @Test(expected = ValidationException.class)
+  public void shouldThrowExceptionWhenFilterIsxnParameterIsEmpty() {
+    validator.validate(fqb.selected("selected").type("book").isxn("").build(), null);
+  }
+
+  @Test(expected = ValidationException.class)
+  public void shouldThrowExceptionWhenFilterSubjectParameterIsEmpty() {
+    validator.validate(fqb.selected("selected").type("book").subject("").build(), null);
+  }
+
+  @Test(expected = ValidationException.class)
+  public void shouldThrowExceptionWhenFilterPublisherParameterIsEmpty() {
+    validator.validate(fqb.selected("selected").type("book").publisher("").build(), null);
+  }
+}


### PR DESCRIPTION
Jira: MODCXEKB-80

## Purpose
Make common validation for mod-kb-ebsco-java and folio-holdingsiq-client

## Approach
Move parameter validators,
Change constructors to accept Configuration,
Remove parameter mapping specific to mod-kb-ebsco-java