### PR TITLE
Add util method to cache and revert unnecessary commit

### DIFF
--- a/src/main/java/org/folio/cache/VertxCache.java
+++ b/src/main/java/org/folio/cache/VertxCache.java
@@ -3,8 +3,7 @@ package org.folio.cache;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.CompletableFuture;
-
-import org.glassfish.jersey.internal.util.Producer;
+import java.util.function.Supplier;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.shareddata.LocalMap;
@@ -48,12 +47,12 @@ public class VertxCache<K, V> {
     }
   }
 
-  public CompletableFuture<V> getValueOrLoad(K key, Producer<CompletableFuture<V>> loader){
+  public CompletableFuture<V> getValueOrLoad(K key, Supplier<CompletableFuture<V>> loader){
     V value = getValue(key);
     if (value != null) {
       return CompletableFuture.completedFuture(value);
     } else {
-      return loader.call()
+      return loader.get()
         .thenCompose(newValue -> {
           putValue(key, newValue);
           return CompletableFuture.completedFuture(newValue);

--- a/src/main/java/org/folio/cache/VertxCache.java
+++ b/src/main/java/org/folio/cache/VertxCache.java
@@ -2,6 +2,9 @@ package org.folio.cache;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.concurrent.CompletableFuture;
+
+import org.glassfish.jersey.internal.util.Producer;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.shareddata.LocalMap;
@@ -42,6 +45,19 @@ public class VertxCache<K, V> {
       return null;
     } else {
       return configurationWrapper.getCacheValue();
+    }
+  }
+
+  public CompletableFuture<V> getValueOrLoad(K key, Producer<CompletableFuture<V>> loader){
+    V value = getValue(key);
+    if (value != null) {
+      return CompletableFuture.completedFuture(value);
+    } else {
+      return loader.call()
+        .thenCompose(newValue -> {
+          putValue(key, newValue);
+          return CompletableFuture.completedFuture(newValue);
+        });
     }
   }
 

--- a/src/main/java/org/folio/holdingsiq/service/ProviderHoldingsIQService.java
+++ b/src/main/java/org/folio/holdingsiq/service/ProviderHoldingsIQService.java
@@ -1,6 +1,5 @@
 package org.folio.holdingsiq.service;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.folio.holdingsiq.model.Sort;
@@ -13,7 +12,6 @@ public interface ProviderHoldingsIQService {
   CompletableFuture<Long> getVendorId();
   CompletableFuture<VendorById> retrieveProvider(long id);
   CompletableFuture<Vendors> retrieveProviders(String q, int page, int count, Sort sort);
-  CompletableFuture<Vendors> retrieveProviders(List<Long> ids);
   CompletableFuture<VendorById> updateProvider(long id, VendorPut rmapiVendor);
 
 }

--- a/src/main/java/org/folio/holdingsiq/service/impl/ConfigurationServiceCache.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/ConfigurationServiceCache.java
@@ -27,18 +27,10 @@ public class ConfigurationServiceCache implements ConfigurationService {
 
   @Override
   public CompletableFuture<Configuration> retrieveConfiguration(OkapiData okapiData) {
-    Configuration cachedConfiguration = configurationCache
-      .getValue(okapiData.getTenant());
-    if(cachedConfiguration != null){
-      return CompletableFuture.completedFuture(cachedConfiguration);
-    }
-
-    return configurationService.retrieveConfiguration(okapiData)
-    .thenCompose(configuration -> {
-      configurationCache
-        .putValue(okapiData.getTenant(), configuration);
-      return CompletableFuture.completedFuture(configuration);
-    });
+    return configurationCache
+      .getValueOrLoad(okapiData.getTenant(),
+        () -> configurationService.retrieveConfiguration(okapiData)
+      );
   }
 
   @Override

--- a/src/main/java/org/folio/holdingsiq/service/impl/ProviderHoldingsIQServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/ProviderHoldingsIQServiceImpl.java
@@ -2,7 +2,6 @@ package org.folio.holdingsiq.service.impl;
 
 import static org.folio.holdingsiq.service.impl.HoldingsRequestHelper.VENDORS_PATH;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import io.vertx.core.Vertx;
@@ -67,8 +66,4 @@ public class ProviderHoldingsIQServiceImpl implements ProviderHoldingsIQService 
     return holdingsRequestHelper.getRequest(holdingsRequestHelper.constructURL(VENDORS_PATH + "?" + query), Vendors.class);
   }
 
-  @Override
-  public CompletableFuture<Vendors> retrieveProviders(List<Long> ids) {
-    throw new UnsupportedOperationException("Not implemented");
-  }
 }

--- a/src/test/java/org/folio/cache/VertxCacheTest.java
+++ b/src/test/java/org/folio/cache/VertxCacheTest.java
@@ -1,0 +1,72 @@
+package org.folio.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.glassfish.jersey.internal.util.Producer;
+import org.junit.Test;
+
+import io.vertx.core.Vertx;
+
+public class VertxCacheTest {
+
+  private static final String KEY = "key";
+  private static final String VALUE = "value";
+  private final VertxCache<String, String> testCache = new VertxCache<>(Vertx.vertx(), 60, "testCache");
+
+  @Test
+  public void shouldInitiallyReturnNull() {
+    assertNull(testCache.getValue(KEY));
+  }
+
+  @Test
+  public void shouldCacheValueAfterPut() {
+    testCache.putValue(KEY, VALUE);
+    assertEquals(VALUE, testCache.getValue(KEY));
+  }
+
+  @Test
+  public void shouldLoadValueOnCacheMiss() {
+    Producer<CompletableFuture<String>> loader = spy(new TestProducer());
+    CompletableFuture<String> returnedValue = testCache.getValueOrLoad(KEY, loader);
+    assertEquals(VALUE, testCache.getValue(KEY));
+    assertEquals(VALUE, returnedValue.join());
+    verify(loader).call();
+  }
+
+  @Test
+  public void shouldNotLoadValueOnCacheHit() {
+    Producer<CompletableFuture<String>> loader = spy(new TestProducer());
+    testCache.putValue(KEY, VALUE);
+    CompletableFuture<String> returnedValue = testCache.getValueOrLoad(KEY, loader);
+    assertEquals(VALUE, testCache.getValue(KEY));
+    assertEquals(VALUE, returnedValue.join());
+    verifyZeroInteractions(loader);
+  }
+
+  @Test
+  public void shouldInvalidateCache() {
+    testCache.putValue(KEY, VALUE);
+    testCache.invalidateAll();
+    assertNull(testCache.getValue(KEY));
+  }
+
+  @Test
+  public void shouldInvalidateCacheByKey() {
+    testCache.putValue(KEY, VALUE);
+    testCache.invalidate(KEY);
+    assertNull(testCache.getValue(KEY));
+  }
+
+  private static class TestProducer implements Producer<CompletableFuture<String>>{
+    @Override
+    public CompletableFuture<String> call() {
+      return CompletableFuture.completedFuture(VALUE);
+    }
+  }
+}

--- a/src/test/java/org/folio/cache/VertxCacheTest.java
+++ b/src/test/java/org/folio/cache/VertxCacheTest.java
@@ -7,11 +7,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 import java.util.concurrent.CompletableFuture;
-
-import org.glassfish.jersey.internal.util.Producer;
-import org.junit.Test;
+import java.util.function.Supplier;
 
 import io.vertx.core.Vertx;
+import org.junit.Test;
 
 public class VertxCacheTest {
 
@@ -32,16 +31,16 @@ public class VertxCacheTest {
 
   @Test
   public void shouldLoadValueOnCacheMiss() {
-    Producer<CompletableFuture<String>> loader = spy(new TestProducer());
+    Supplier<CompletableFuture<String>> loader = spy(new TestProducer());
     CompletableFuture<String> returnedValue = testCache.getValueOrLoad(KEY, loader);
     assertEquals(VALUE, testCache.getValue(KEY));
     assertEquals(VALUE, returnedValue.join());
-    verify(loader).call();
+    verify(loader).get();
   }
 
   @Test
   public void shouldNotLoadValueOnCacheHit() {
-    Producer<CompletableFuture<String>> loader = spy(new TestProducer());
+    Supplier<CompletableFuture<String>> loader = spy(new TestProducer());
     testCache.putValue(KEY, VALUE);
     CompletableFuture<String> returnedValue = testCache.getValueOrLoad(KEY, loader);
     assertEquals(VALUE, testCache.getValue(KEY));
@@ -63,9 +62,9 @@ public class VertxCacheTest {
     assertNull(testCache.getValue(KEY));
   }
 
-  private static class TestProducer implements Producer<CompletableFuture<String>>{
+  private static class TestProducer implements Supplier<CompletableFuture<String>> {
     @Override
-    public CompletableFuture<String> call() {
+    public CompletableFuture<String> get() {
       return CompletableFuture.completedFuture(VALUE);
     }
   }

--- a/src/test/java/org/folio/holdingsiq/service/config/ConfigTestData.java
+++ b/src/test/java/org/folio/holdingsiq/service/config/ConfigTestData.java
@@ -1,0 +1,16 @@
+package org.folio.holdingsiq.service.config;
+
+import org.folio.holdingsiq.model.OkapiData;
+
+import com.google.common.collect.ImmutableMap;
+
+public class ConfigTestData {
+  public static final String OKAPI_TOKEN_HEADER = "x-okapi-token";
+  public static final String OKAPI_URL_HEADER = "x-okapi-url";
+  public static final String OKAPI_TENANT_HEADER = "x-okapi-tenant";
+
+  public static final OkapiData OKAPI_DATA = new OkapiData(ImmutableMap.of(
+    OKAPI_TOKEN_HEADER, "token",
+    OKAPI_TENANT_HEADER, "tenant",
+    OKAPI_URL_HEADER, "https://localhost:8080"));
+}

--- a/src/test/java/org/folio/holdingsiq/service/config/ConfigurationServiceCacheTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/config/ConfigurationServiceCacheTest.java
@@ -1,0 +1,42 @@
+package org.folio.holdingsiq.service.config;
+
+import static org.folio.holdingsiq.service.config.ConfigTestData.OKAPI_DATA;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.cache.VertxCache;
+import org.folio.holdingsiq.model.Configuration;
+import org.folio.holdingsiq.service.ConfigurationService;
+import org.folio.holdingsiq.service.impl.ConfigurationServiceCache;
+import org.junit.Test;
+
+import io.vertx.core.Vertx;
+
+public class ConfigurationServiceCacheTest {
+
+  public static final Configuration STUB_CONFIGURATION = Configuration.builder().build();
+  private final VertxCache<String, Configuration> testCache = new VertxCache<>(Vertx.vertx(), 60, "testCache");
+  private final ConfigurationService mockService = mock(ConfigurationService.class);
+
+  @Test
+  public void shouldDelegateToOtherServiceOnCacheMiss() {
+    when(mockService.retrieveConfiguration(any())).thenReturn(CompletableFuture.completedFuture(STUB_CONFIGURATION));
+    ConfigurationServiceCache cacheService = new ConfigurationServiceCache(mockService, testCache);
+    cacheService.retrieveConfiguration(OKAPI_DATA);
+    verify(mockService).retrieveConfiguration(any());
+  }
+
+  @Test
+  public void shouldUseCachedValueOnCacheHit() {
+    testCache.putValue(OKAPI_DATA.getTenant(), STUB_CONFIGURATION);
+    ConfigurationServiceCache cacheService = new ConfigurationServiceCache(mockService, testCache);
+    cacheService.retrieveConfiguration(OKAPI_DATA);
+    verifyZeroInteractions(mockService);
+  }
+
+}

--- a/src/test/java/org/folio/holdingsiq/service/config/RMAPIConfigurationServiceTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/config/RMAPIConfigurationServiceTest.java
@@ -1,14 +1,20 @@
 package org.folio.holdingsiq.service.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
-import io.vertx.core.Handler;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.buffer.impl.BufferImpl;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.impl.HttpClientResponseImpl;
+import static org.folio.holdingsiq.service.config.ConfigTestData.OKAPI_DATA;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+
 import org.folio.holdingsiq.model.Configuration;
-import org.folio.holdingsiq.model.OkapiData;
 import org.folio.holdingsiq.service.impl.ConfigurationClientProvider;
 import org.folio.holdingsiq.service.impl.ConfigurationServiceImpl;
 import org.folio.rest.client.ConfigurationsClient;
@@ -19,24 +25,16 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
-import java.util.concurrent.CompletableFuture;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.buffer.impl.BufferImpl;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.impl.HttpClientResponseImpl;
 
 public class RMAPIConfigurationServiceTest {
 
-  private static final String OKAPI_TOKEN_HEADER = "x-okapi-token";
-  private static final String OKAPI_URL_HEADER = "x-okapi-url";
-  private static final String OKAPI_TENANT_HEADER = "x-okapi-tenant";
-
-  private static final OkapiData OKAPI_DATA = new OkapiData(ImmutableMap.of(
-    OKAPI_TOKEN_HEADER, "token",
-    OKAPI_TENANT_HEADER, "tenant",
-    OKAPI_URL_HEADER, "https://localhost:8080"));
   private ConfigurationClientProvider configurationClientProvider = mock(ConfigurationClientProvider.class);
   private ConfigurationsClient mockConfigurationsClient = mock(ConfigurationsClient.class);
   private ConfigurationServiceImpl configurationService = new ConfigurationServiceImpl(configurationClientProvider);


### PR DESCRIPTION
## Purpose
Add getValueOrLoad method, to refactor usage of cache in mod-kb-ebsco-java
Revert commit that added retrieveProviders(List<Long> ids), because this method is not needed anymore.
