### PR TITLE
MODKBEKBJ-339: Remove dependency on RMB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,16 +19,21 @@
   </licenses>
 
   <properties>
-    <vertx.version>3.5.4</vertx.version>
+    <vertx.version>3.8.1</vertx.version>
     <junit.version>4.12</junit.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>domain-models-runtime</artifactId>
-      <version>23.5.0</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.10.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.10.1</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/src/test/java/org/folio/holdingsiq/service/impl/ProviderHoldingsIQServiceImplTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/ProviderHoldingsIQServiceImplTest.java
@@ -20,6 +20,9 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 public class ProviderHoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig {
 
   private ProviderHoldingsIQServiceImpl providerHoldingsIQService =
@@ -74,9 +77,9 @@ public class ProviderHoldingsIQServiceImplTest extends HoldingsIQServiceTestConf
   }
 
   @Test
-  public void testRetrieveVendorsCompleteExceptionallyWhenThrowServiceException() throws IOException {
+  public void testRetrieveVendorsCompleteExceptionallyWhenThrowServiceException() throws JsonProcessingException {
     mockResponse(mockResponseBody, mockResponse, "{}", HttpStatus.SC_OK);
-    when(Json.mapper.readValue(anyString(), any(Class.class))).thenThrow(IOException.class);
+    when(Json.mapper.readValue(anyString(), any(Class.class))).thenThrow(JsonParseException.class);
 
     CompletableFuture<Vendors> future = providerHoldingsIQService.retrieveProviders("Busket",
       PAGE_FOR_PARAM, COUNT_FOR_PARAM, Sort.NAME);


### PR DESCRIPTION
## Purpose
Remove dependency on RMB

## Learning
folio-holdings-client doesn't use RMB, so we can safely remove it from list of dependencies