### PR TITLE
MODKBEKBJ-381 - Investigate using a different RM API Endpoint for status checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,20 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.1.2</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.1</version>
         <configuration>

--- a/src/main/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceImpl.java
@@ -1,7 +1,5 @@
 package org.folio.holdingsiq.service.impl;
 
-import static org.folio.holdingsiq.service.impl.HoldingsRequestHelper.VENDORS_PATH;
-
 import java.util.concurrent.CompletableFuture;
 
 import io.vertx.core.Vertx;
@@ -21,7 +19,7 @@ public class HoldingsIQServiceImpl implements HoldingsIQService {
 
   @Override
   public CompletableFuture<Object> verifyCredentials() {
-    return holdingsRequestHelper.getRequest(holdingsRequestHelper.constructURL(VENDORS_PATH + "?search=zz12&offset=1&orderby=vendorname&count=1"), Object.class);
+    return holdingsRequestHelper.getRequest(holdingsRequestHelper.constructURL(""), Object.class);
   }
 
   @Override

--- a/src/test/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceImplTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceImplTest.java
@@ -1,26 +1,26 @@
 package org.folio.holdingsiq.service.impl;
 
-import org.apache.http.HttpStatus;
-import org.folio.holdingsiq.model.Proxies;
-import org.folio.holdingsiq.model.RootProxyCustomLabels;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
-
-import io.vertx.core.json.Json;
-
-import static org.folio.holdingsiq.service.util.TestUtil.mockResponse;
-import static org.folio.holdingsiq.service.util.TestUtil.mockResponseForUpdateAndCreate;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
+
+import static org.folio.holdingsiq.service.util.TestUtil.mockResponse;
+import static org.folio.holdingsiq.service.util.TestUtil.mockResponseForUpdateAndCreate;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.vertx.core.json.Json;
+import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.folio.holdingsiq.model.Proxies;
+import org.folio.holdingsiq.model.RootProxyCustomLabels;
 
 public class HoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig {
 
@@ -40,8 +40,7 @@ public class HoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig {
     CompletableFuture<Object> completableFuture = service.verifyCredentials();
 
     assertTrue(isCompletedNormally(completableFuture));
-    verify(mockClient).getAbs(STUB_BASE_URL + "/rm/rmaccounts/" + STUB_CUSTOMER_ID
-      + "/vendors?search=zz12&offset=1&orderby=vendorname&count=1");
+    verify(mockClient).getAbs(STUB_BASE_URL + "/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/");
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Updated due to https://issues.folio.org/browse/MODKBEKBJ-381

## Approach
* updated URL to check the status from ../vendors?search=zz12&offset=1&orderby=vendorname&count=1 to .../{custid}
* updated test