### PR TITLE
MODKBEKBJ-432 Get configuration settings from eHoldings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
   <properties>
     <vertx.version>3.8.4</vertx.version>
     <junit.version>4.12</junit.version>
+    <powermock.version>2.0.2</powermock.version>
     <folio-service-tools.version>1.4.1</folio-service-tools.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -105,6 +106,18 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>2.24.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,9 @@
   </licenses>
 
   <properties>
-    <vertx.version>3.8.1</vertx.version>
+    <vertx.version>3.8.4</vertx.version>
     <junit.version>4.12</junit.version>
+    <folio-service-tools.version>1.4.1</folio-service-tools.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -51,9 +52,14 @@
       <version>${vertx.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+      <version>${vertx.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.folio</groupId>
-      <artifactId>mod-configuration-client</artifactId>
-      <version>4.0.3</version>
+      <artifactId>folio-service-tools-dev</artifactId>
+      <version>${folio-service-tools.version}</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <vertx.version>3.8.4</vertx.version>
     <junit.version>4.12</junit.version>
     <powermock.version>2.0.2</powermock.version>
-    <folio-service-tools.version>1.4.1</folio-service-tools.version>
+    <folio-service-tools.version>1.4.2-SNAPSHOT</folio-service-tools.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/src/main/java/org/folio/holdingsiq/service/ConfigurationService.java
+++ b/src/main/java/org/folio/holdingsiq/service/ConfigurationService.java
@@ -13,5 +13,6 @@ public interface ConfigurationService {
 
   CompletableFuture<Configuration> retrieveConfiguration(OkapiData okapiData);
 
-  CompletableFuture<List<ConfigurationError>> verifyCredentials(Configuration configuration, Context vertxContext, String tenant);
+  CompletableFuture<List<ConfigurationError>> verifyCredentials(Configuration configuration, Context vertxContext,
+                                                                OkapiData okapiData);
 }

--- a/src/main/java/org/folio/holdingsiq/service/ConfigurationService.java
+++ b/src/main/java/org/folio/holdingsiq/service/ConfigurationService.java
@@ -13,7 +13,5 @@ public interface ConfigurationService {
 
   CompletableFuture<Configuration> retrieveConfiguration(OkapiData okapiData);
 
-  CompletableFuture<Configuration> updateConfiguration(Configuration configuration, OkapiData okapiData);
-
   CompletableFuture<List<ConfigurationError>> verifyCredentials(Configuration configuration, Context vertxContext, String tenant);
 }

--- a/src/main/java/org/folio/holdingsiq/service/exception/ConfigurationServiceException.java
+++ b/src/main/java/org/folio/holdingsiq/service/exception/ConfigurationServiceException.java
@@ -6,6 +6,7 @@ public class ConfigurationServiceException extends RuntimeException {
   private final Integer statusCode;
 
   public ConfigurationServiceException(String responseBody, Integer statusCode) {
+    super("Status code: " + statusCode);
     this.responseBody = responseBody;
     this.statusCode = statusCode;
   }

--- a/src/main/java/org/folio/holdingsiq/service/impl/ConfigurationServiceCache.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/ConfigurationServiceCache.java
@@ -34,16 +34,6 @@ public class ConfigurationServiceCache implements ConfigurationService {
   }
 
   @Override
-  public CompletableFuture<Configuration> updateConfiguration(Configuration rmapiConfiguration, OkapiData okapiData) {
-    return configurationService.updateConfiguration(rmapiConfiguration, okapiData)
-    .thenCompose(configuration ->  {
-      configurationCache
-        .putValue(okapiData.getTenant(), configuration);
-      return CompletableFuture.completedFuture(configuration);
-    });
-  }
-
-  @Override
   public CompletableFuture<List<ConfigurationError>> verifyCredentials(Configuration configuration, Context vertxContext, String tenant) {
     if(configuration.getConfigValid() != null && configuration.getConfigValid()){
       return CompletableFuture.completedFuture(Collections.emptyList());

--- a/src/main/java/org/folio/holdingsiq/service/impl/ConfigurationServiceCache.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/ConfigurationServiceCache.java
@@ -1,5 +1,9 @@
 package org.folio.holdingsiq.service.impl;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -11,12 +15,13 @@ import org.folio.holdingsiq.model.Configuration;
 import org.folio.holdingsiq.model.ConfigurationError;
 import org.folio.holdingsiq.model.OkapiData;
 import org.folio.holdingsiq.service.ConfigurationService;
+import org.folio.util.TokenUtils;
 
 public class ConfigurationServiceCache implements ConfigurationService {
 
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  private VertxCache<String, Configuration> configurationCache;
+  private final VertxCache<String, Configuration> configurationCache;
 
 
   public ConfigurationServiceCache(ConfigurationService configurationService,
@@ -27,26 +32,38 @@ public class ConfigurationServiceCache implements ConfigurationService {
 
   @Override
   public CompletableFuture<Configuration> retrieveConfiguration(OkapiData okapiData) {
-    return configurationCache
-      .getValueOrLoad(okapiData.getTenant(),
-        () -> configurationService.retrieveConfiguration(okapiData)
+    return TokenUtils.fetchUserInfo(okapiData.getApiToken())
+      .thenCompose(userInfo -> configurationCache.getValueOrLoad(
+          userInfo.getUserId(),
+          () -> configurationService.retrieveConfiguration(okapiData))
       );
   }
 
   @Override
   public CompletableFuture<List<ConfigurationError>> verifyCredentials(Configuration configuration, Context vertxContext,
                                                                        OkapiData okapiData) {
-    if(configuration.getConfigValid() != null && configuration.getConfigValid()){
-      return CompletableFuture.completedFuture(Collections.emptyList());
+    if (configuration.getConfigValid() != null && configuration.getConfigValid()) {
+      return completedFuture(emptyList());
     }
+
     return configurationService.verifyCredentials(configuration, vertxContext, okapiData)
       .thenCompose(errors -> {
-        if(errors.isEmpty()){
-          configurationCache.putValue(okapiData.getTenant(),
-            configuration.toBuilder().configValid(true).build());
+        if (!errors.isEmpty()) {
+          return completedFuture(errors);
         }
-        return CompletableFuture.completedFuture(errors);
+
+        return storeConfigurationInCache(configuration, okapiData)
+          .thenApply(v -> Collections.<ConfigurationError>emptyList())
+          .exceptionally(t -> singletonList(new ConfigurationError(t.getMessage())));
       });
+  }
+
+  private CompletableFuture<Void> storeConfigurationInCache(Configuration config, OkapiData okapiData) {
+    return TokenUtils.fetchUserInfo(okapiData.getApiToken())
+      .thenAccept(userInfo -> configurationCache.putValue(
+          userInfo.getUserId(),
+          config.toBuilder().configValid(true).build())
+      );
   }
 
 }

--- a/src/main/java/org/folio/holdingsiq/service/impl/ConfigurationServiceCache.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/ConfigurationServiceCache.java
@@ -34,14 +34,15 @@ public class ConfigurationServiceCache implements ConfigurationService {
   }
 
   @Override
-  public CompletableFuture<List<ConfigurationError>> verifyCredentials(Configuration configuration, Context vertxContext, String tenant) {
+  public CompletableFuture<List<ConfigurationError>> verifyCredentials(Configuration configuration, Context vertxContext,
+                                                                       OkapiData okapiData) {
     if(configuration.getConfigValid() != null && configuration.getConfigValid()){
       return CompletableFuture.completedFuture(Collections.emptyList());
     }
-    return configurationService.verifyCredentials(configuration, vertxContext, tenant)
+    return configurationService.verifyCredentials(configuration, vertxContext, okapiData)
       .thenCompose(errors -> {
         if(errors.isEmpty()){
-          configurationCache.putValue(tenant,
+          configurationCache.putValue(okapiData.getTenant(),
             configuration.toBuilder().configValid(true).build());
         }
         return CompletableFuture.completedFuture(errors);

--- a/src/main/java/org/folio/holdingsiq/service/impl/ConfigurationServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/ConfigurationServiceImpl.java
@@ -37,7 +37,7 @@ import org.folio.holdingsiq.service.exception.ConfigurationServiceException;
 import org.folio.rest.tools.utils.TenantTool;
 
 /**
- * Retrieves the RM API connection details from mod-configuration.
+ * Retrieves the RM API connection details from eHoldings.
  */
 public class ConfigurationServiceImpl implements ConfigurationService {
 
@@ -83,7 +83,8 @@ public class ConfigurationServiceImpl implements ConfigurationService {
     } else {
       CredentialsReader reader = CredentialsReader.from(creds);
 
-      LOG.info("User credentials retrieved: id = '%s', name = '%s'", reader.getId(), reader.getName());
+      LOG.info("User credentials retrieved: id = '" + reader.getId() + "', " +
+        "name = '" + reader.getName() + "'");
     }
   }
 

--- a/src/main/java/org/folio/holdingsiq/service/impl/ConfigurationServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/ConfigurationServiceImpl.java
@@ -1,30 +1,37 @@
 package org.folio.holdingsiq.service.impl;
 
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.http.HttpHeaders.ACCEPT;
 
-import java.io.UnsupportedEncodingException;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+import static org.folio.util.FutureUtils.mapVertxFuture;
+
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import org.apache.commons.validator.routines.UrlValidator;
+import org.apache.http.HttpStatus;
 
 import org.folio.holdingsiq.model.Configuration;
 import org.folio.holdingsiq.model.ConfigurationError;
 import org.folio.holdingsiq.model.OkapiData;
 import org.folio.holdingsiq.service.ConfigurationService;
 import org.folio.holdingsiq.service.exception.ConfigurationServiceException;
-import org.folio.rest.client.ConfigurationsClient;
-import org.folio.rest.jaxrs.model.Config;
-import org.folio.rest.tools.client.Response;
 import org.folio.rest.tools.utils.TenantTool;
 
 /**
@@ -32,232 +39,85 @@ import org.folio.rest.tools.utils.TenantTool;
  */
 public class ConfigurationServiceImpl implements ConfigurationService {
 
-  private static final String EBSCO_URL_CODE = "kb.ebsco.url";
-  private static final String EBSCO_API_KEY_CODE = "kb.ebsco.apiKey";
-  private static final String EBSCO_CUSTOMER_ID_CODE = "kb.ebsco.customerId";
-  private static final List<String> RM_API_CONFIG_KEYS = Arrays.asList(EBSCO_CUSTOMER_ID_CODE, EBSCO_API_KEY_CODE,
-      EBSCO_URL_CODE);
-  private static final int QUERY_LIMIT = 100;
+  private static final String JSON_API_TYPE = "application/vnd.api+json";
+  private static final String USER_CREDS_URL = "/eholdings/user-kb-credential";
 
-  private ConfigurationClientProvider configurationClientProvider;
+  private final WebClient client;
 
-  /**
-   * @param configurationClientProvider object used to get http client for sending request to okapi
-   */
-  public ConfigurationServiceImpl(ConfigurationClientProvider configurationClientProvider) {
-    this.configurationClientProvider = configurationClientProvider;
+
+  public ConfigurationServiceImpl(Vertx vertx) {
+    this.client = WebClient.create(vertx);
   }
 
   @Override
   public CompletableFuture<Configuration> retrieveConfiguration(OkapiData okapiData) {
-    return retrieveConfigurations(okapiData)
-      .thenCompose(configurations ->
-        CompletableFuture.completedFuture(mapResults(configurations.getJsonArray("configs"))));
-  }
-
-  /**
-   * Removes old configuration and adds new configuration for RM API
-   */
-  @Override
-  public CompletableFuture<Configuration> updateConfiguration(Configuration configuration, OkapiData okapiData) {
-    return retrieveConfigurations(okapiData)
-      .thenCompose(configurations -> {
-        List<String> ids = mapToIds(configurations.getJsonArray("configs"));
-        return deleteConfigurations(ids, okapiData);
-      })
-      .thenCompose(o -> {
-        List<Config> configurations = Arrays.asList(
-          createConfig(configuration.getUrl(), EBSCO_URL_CODE, "EBSCO RM-API URL"),
-          createConfig(configuration.getApiKey(), EBSCO_API_KEY_CODE, "EBSCO RM-API API Key"),
-          createConfig(configuration.getCustomerId(), EBSCO_CUSTOMER_ID_CODE, "EBSCO RM-API Customer ID")
-        );
-        return postConfigurations(configurations, okapiData);
-      })
-      .thenCompose(aVoid -> CompletableFuture.completedFuture(configuration));
+    return getUserCredentials(okapiData).thenApply(this::credentialsToConfiguration);
   }
 
   @Override
-  public CompletableFuture<List<ConfigurationError>> verifyCredentials(
-    Configuration configuration, Context vertxContext, String tenant) {
+  public CompletableFuture<List<ConfigurationError>> verifyCredentials(Configuration configuration,
+                                                                       Context vertxContext, String tenant) {
     List<ConfigurationError> errors = new ArrayList<>();
+
     if (!isConfigurationParametersValid(configuration, errors)) {
-      return CompletableFuture.completedFuture(errors);
+      return completedFuture(errors);
     }
+
     return new HoldingsIQServiceImpl(configuration, vertxContext.owner())
       .verifyCredentials()
-      .thenCompose(o -> CompletableFuture.completedFuture(Collections.<ConfigurationError>emptyList()))
+      .thenCompose(o -> completedFuture(Collections.<ConfigurationError>emptyList()))
       .exceptionally(e -> Collections.singletonList(new ConfigurationError("KB API Credentials are invalid")));
   }
 
-  /**
-   * Get configuration object from mod-configuration in the form of json
-   *
-   * @param okapiData data of OKAPI server from which configuration is retrieved
-   * @return future that will complete when configuration is retrieved
-   */
-  private CompletableFuture<JsonObject> retrieveConfigurations(OkapiData okapiData) {
-    final String tenantId = TenantTool.calculateTenantId(okapiData.getTenant());
-    CompletableFuture<JsonObject> future = new CompletableFuture<>();
-    try {
-      ConfigurationsClient configurationsClient = configurationClientProvider
-        .createClient(okapiData.getOkapiHost(), okapiData.getOkapiPort(), tenantId, okapiData.getApiToken());
-      configurationsClient.getEntries("module=EKB", 0, QUERY_LIMIT, null, null, response ->
-        response.bodyHandler(body -> {
-          if (verifyResponse(response, body, future)) {
-            future.complete(body.toJsonObject());
-          }
-        }));
-    } catch (UnsupportedEncodingException e) {
-      future.completeExceptionally(e);
+  private CompletableFuture<JsonObject> getUserCredentials(OkapiData okapiData) {
+    return mapVertxFuture(getJson(USER_CREDS_URL, okapiData));
+  }
+
+  private Future<JsonObject> getJson(String requestUrl, OkapiData okapiData) {
+    Promise<HttpResponse<Buffer>> promise = Promise.promise();
+
+    client.get(okapiData.getOkapiPort(), okapiData.getOkapiHost(), requestUrl)
+      .putHeader(OKAPI_HEADER_TENANT, TenantTool.calculateTenantId(okapiData.getTenant()))
+      .putHeader(OKAPI_HEADER_TOKEN, okapiData.getApiToken())
+      .putHeader(ACCEPT, JSON_API_TYPE)
+      .expect(ResponsePredicate.contentType(JSON_API_TYPE))
+      .send(promise);
+
+    return promise.future().compose(res ->
+      res.statusCode() == HttpStatus.SC_OK
+        ? succeededFuture(res.bodyAsJsonObject())
+        : failedFuture(new ConfigurationServiceException(res.toString(), res.statusCode())));
+  }
+
+  private Configuration credentialsToConfiguration(JsonObject creds) {
+    Configuration.ConfigurationBuilder builder = Configuration.builder();
+
+    if (creds != null) {
+      JsonObject attrs = creds.getJsonObject("attributes");
+
+      if (attrs != null) {
+        builder.customerId(attrs.getString("customerId"));
+        builder.apiKey(attrs.getString("apiKey"));
+        builder.url(attrs.getString("url"));
+      }
     }
-    return future;
-  }
 
-  /**
-   * Sends a delete request for each configuration in the list
-   *
-   * @param okapiData        data of OKAPI server to which delete requests are sent
-   * @param configurationIds ids of configurations to be deleted
-   * @return future that will complete when all configurations are deleted
-   */
-  private CompletableFuture<Void> deleteConfigurations(List<String> configurationIds, OkapiData okapiData) {
-    final String tenantId = TenantTool.calculateTenantId(okapiData.getTenant());
-    List<CompletableFuture<Void>> futures = new ArrayList<>();
-    ConfigurationsClient configurationsClient = configurationClientProvider
-      .createClient(okapiData.getOkapiHost(), okapiData.getOkapiPort(), tenantId, okapiData.getApiToken());
-    for (String id : configurationIds) {
-      futures.add(deleteConfiguration(configurationsClient, id));
-    }
-    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-  }
-
-  /**
-   * Sends a delete request for configuration id
-   *
-   * @return future that will complete when configuration is deleted
-   */
-  private CompletableFuture<Void> deleteConfiguration(ConfigurationsClient configurationsClient, String configurationId) {
-    CompletableFuture<Void> future = new CompletableFuture<>();
-    try {
-      configurationsClient.deleteEntryId(configurationId, null, response -> response.bodyHandler(body -> {
-        if (verifyResponse(response, body, future)) {
-          future.complete(null);
-        }
-      }));
-    } catch (UnsupportedEncodingException e) {
-      future.completeExceptionally(e);
-    }
-    return future;
-  }
-
-  /**
-   * Sends a post request for each configuration in the list
-   *
-   * @param okapiData      data of OKAPI server to which configurations are posted
-   * @param configurations configurations to post
-   * @return future that will complete when all configurations are posted
-   */
-  private CompletableFuture<Void> postConfigurations(List<Config> configurations, OkapiData okapiData) {
-    final String tenantId = TenantTool.calculateTenantId(okapiData.getTenant());
-    List<CompletableFuture<Void>> futures = new ArrayList<>();
-    ConfigurationsClient configurationsClient = configurationClientProvider
-      .createClient(okapiData.getOkapiHost(), okapiData.getOkapiPort(), tenantId, okapiData.getApiToken());
-    for (Config configuration : configurations) {
-      futures.add(postConfiguration(configurationsClient, configuration));
-    }
-    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-
-  }
-
-  /**
-   * Sends a post request to create configuration
-   *
-   * @return future that will complete when configuration is created
-   */
-  private CompletableFuture<Void> postConfiguration(ConfigurationsClient configurationsClient, Config configuration) {
-    CompletableFuture<Void> future = new CompletableFuture<>();
-    try {
-      configurationsClient.postEntries(null, configuration, response -> response.bodyHandler(body -> {
-        if (verifyResponse(response, body, future)) {
-          future.complete(null);
-        }
-      }));
-    } catch (Exception e) {
-      future.completeExceptionally(e);
-    }
-    return future;
-  }
-
-  /**
-   * Completes future exceptionally if response is not successful
-   *
-   * @return true if response is successful
-   */
-  private boolean verifyResponse(HttpClientResponse response, Buffer responseBody, CompletableFuture<?> future) {
-    if (!Response.isSuccess(response.statusCode())) {
-      future.completeExceptionally(new ConfigurationServiceException(responseBody.toString(), response.statusCode()));
-      return false;
-    }
-    return true;
-  }
-
-  /**
-   * Simple mapper for the results of mod-configuration to Configuration.
-   *
-   * @param configs All the RM API related configurations returned by
-   *                mod-configuration.
-   */
-  private Configuration mapResults(JsonArray configs) {
-    Configuration.ConfigurationBuilder configBuilder = Configuration.builder();
-    configs.stream()
-      .filter(JsonObject.class::isInstance)
-      .map(JsonObject.class::cast)
-      .forEach(entry -> {
-        String code = entry.getString("code");
-        String value = entry.getString("value");
-        if (EBSCO_CUSTOMER_ID_CODE.equalsIgnoreCase(code)) {
-          configBuilder.customerId(value);
-        } else if (EBSCO_API_KEY_CODE.equalsIgnoreCase(code)) {
-          configBuilder.apiKey(value);
-        } else if (EBSCO_URL_CODE.equalsIgnoreCase(code)) {
-          configBuilder.url(value);
-        }
-      });
-    return configBuilder.build();
-  }
-
-  private List<String> mapToIds(JsonArray configs) {
-    return configs.stream()
-      .filter(JsonObject.class::isInstance)
-      .map(JsonObject.class::cast)
-      .filter(config -> RM_API_CONFIG_KEYS.contains(config.getString("code")))
-      .map(config -> config.getString("id"))
-      .collect(Collectors.toList());
-  }
-
-  private Config createConfig(String apiKey, String code, String description) {
-    return new Config()
-      .withModule("EKB")
-      .withConfigName("api_access")
-      .withCode(code)
-      .withDescription(description)
-      .withEnabled(true)
-      .withValue(apiKey);
+    return builder.build();
   }
 
   private boolean isConfigurationParametersValid(Configuration configuration, List<ConfigurationError> errors) {
-    if(isEmpty(configuration.getUrl())){
+    if (isEmpty(configuration.getUrl())) {
       errors.add(new ConfigurationError("Url is empty"));
     }
-    if(isEmpty(configuration.getApiKey())){
+    if (isEmpty(configuration.getApiKey())) {
       errors.add(new ConfigurationError("API key is empty"));
     }
-    if(isEmpty(configuration.getCustomerId())){
+    if (isEmpty(configuration.getCustomerId())) {
       errors.add(new ConfigurationError("Customer ID is empty"));
     }
 
     UrlValidator urlValidator = new UrlValidator();
-    if(!urlValidator.isValid(configuration.getUrl())){
+    if (!urlValidator.isValid(configuration.getUrl())) {
       errors.add(new ConfigurationError("Url is invalid"));
     }
 

--- a/src/main/java/org/folio/holdingsiq/service/impl/ConfigurationServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/ConfigurationServiceImpl.java
@@ -60,7 +60,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
   @Override
   public CompletableFuture<List<ConfigurationError>> verifyCredentials(Configuration configuration,
-                                                                       Context vertxContext, String tenant) {
+                                                                       Context vertxContext, OkapiData okapiData) {
     List<ConfigurationError> errors = new ArrayList<>();
 
     if (!isConfigurationParametersValid(configuration, errors)) {

--- a/src/test/java/org/folio/holdingsiq/service/config/ConfigurationServiceCacheTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/config/ConfigurationServiceCacheTest.java
@@ -1,42 +1,156 @@
 package org.folio.holdingsiq.service.config;
 
-import static org.folio.holdingsiq.service.config.ConfigTestData.OKAPI_DATA;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
-import java.util.concurrent.CompletableFuture;
+import static org.folio.holdingsiq.service.config.ConfigTestData.OKAPI_DATA;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.verification.VerificationMode;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import org.folio.cache.VertxCache;
 import org.folio.holdingsiq.model.Configuration;
+import org.folio.holdingsiq.model.ConfigurationError;
 import org.folio.holdingsiq.service.ConfigurationService;
 import org.folio.holdingsiq.service.impl.ConfigurationServiceCache;
-import org.junit.Test;
+import org.folio.util.FutureUtils;
+import org.folio.util.TokenUtils;
+import org.folio.util.UserInfo;
 
-import io.vertx.core.Vertx;
-
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(TokenUtils.class)
+@PowerMockIgnore({"org.apache.logging.log4j.*"})
 public class ConfigurationServiceCacheTest {
 
-  public static final Configuration STUB_CONFIGURATION = Configuration.builder().build();
-  private final VertxCache<String, Configuration> testCache = new VertxCache<>(Vertx.vertx(), 60, "testCache");
-  private final ConfigurationService mockService = mock(ConfigurationService.class);
+  private static final Configuration STUB_CONFIGURATION = Configuration.builder().build();
+  private static final UserInfo STUB_USER_INFO = new UserInfo("USER_ID", "USER_NAME");
 
-  @Test
-  public void shouldDelegateToOtherServiceOnCacheMiss() {
-    when(mockService.retrieveConfiguration(any())).thenReturn(CompletableFuture.completedFuture(STUB_CONFIGURATION));
-    ConfigurationServiceCache cacheService = new ConfigurationServiceCache(mockService, testCache);
-    cacheService.retrieveConfiguration(OKAPI_DATA);
-    verify(mockService).retrieveConfiguration(any());
+  @Mock
+  private Context context;
+  @Mock
+  private ConfigurationService configService;
+  private VertxCache<String, Configuration> testCache;
+  private ConfigurationServiceCache cacheService;
+
+
+  @Before
+  public void setUp() {
+    initMocks(this);
+    mockStatic(TokenUtils.class);
+
+    testCache = new VertxCache<>(Vertx.vertx(), 60, "testCache");
+    cacheService = new ConfigurationServiceCache(configService, testCache);
   }
 
   @Test
-  public void shouldUseCachedValueOnCacheHit() {
-    testCache.putValue(OKAPI_DATA.getTenant(), STUB_CONFIGURATION);
-    ConfigurationServiceCache cacheService = new ConfigurationServiceCache(mockService, testCache);
-    cacheService.retrieveConfiguration(OKAPI_DATA);
-    verifyZeroInteractions(mockService);
+  public void shouldDelegateToOtherServiceOnCacheMiss() throws ExecutionException, InterruptedException {
+    when(TokenUtils.fetchUserInfo(OKAPI_DATA.getApiToken())).thenReturn(completedFuture(STUB_USER_INFO));
+    when(configService.retrieveConfiguration(OKAPI_DATA)).thenReturn(completedFuture(STUB_CONFIGURATION));
+
+    Configuration config = cacheService.retrieveConfiguration(OKAPI_DATA).get();
+
+    assertThat(config, sameInstance(STUB_CONFIGURATION));
+    verify(configService).retrieveConfiguration(OKAPI_DATA);
   }
 
+  @Test
+  public void shouldUseCachedValueOnCacheHit() throws ExecutionException, InterruptedException {
+    when(TokenUtils.fetchUserInfo(OKAPI_DATA.getApiToken())).thenReturn(completedFuture(STUB_USER_INFO));
+    testCache.putValue(STUB_USER_INFO.getUserId(), STUB_CONFIGURATION);
+
+    Configuration config = cacheService.retrieveConfiguration(OKAPI_DATA).get();
+
+    assertThat(config, sameInstance(STUB_CONFIGURATION));
+    verifyZeroInteractions(configService);
+  }
+
+  @Test
+  public void shouldReturnValidConfigurationImmediately() throws ExecutionException, InterruptedException {
+    List<ConfigurationError> errors = cacheService.verifyCredentials(Configuration.builder().configValid(true).build(),
+        context, OKAPI_DATA).get();
+
+    assertThat(errors, Matchers.empty());
+
+    verifyZeroInteractions(configService);
+    verifyTokenUtils(never());
+  }
+
+  @Test
+  public void shouldReturnVerificationErrorsFromService() throws ExecutionException, InterruptedException {
+    ConfigurationError error = new ConfigurationError("ERROR");
+    when(configService.verifyCredentials(STUB_CONFIGURATION, context, OKAPI_DATA))
+      .thenReturn(completedFuture(Collections.singletonList(error)));
+
+    List<ConfigurationError> errors = cacheService.verifyCredentials(STUB_CONFIGURATION, context, OKAPI_DATA).get();
+
+    assertThat(errors, contains(error));
+
+    verify(configService).verifyCredentials(STUB_CONFIGURATION, context, OKAPI_DATA);
+    verifyTokenUtils(never());
+  }
+
+  @Test
+  public void shouldStoreVerifiedConfigurationInCache() throws ExecutionException, InterruptedException {
+    when(configService.verifyCredentials(STUB_CONFIGURATION, context, OKAPI_DATA)).thenReturn(completedFuture(emptyList()));
+    when(TokenUtils.fetchUserInfo(OKAPI_DATA.getApiToken())).thenReturn(completedFuture(STUB_USER_INFO));
+
+    List<ConfigurationError> errors = cacheService.verifyCredentials(STUB_CONFIGURATION, context, OKAPI_DATA).get();
+
+    assertThat(errors, empty());
+    assertThat(testCache.getValue(STUB_USER_INFO.getUserId()),
+      equalTo(STUB_CONFIGURATION.toBuilder().configValid(Boolean.TRUE).build()));
+
+    verify(configService).verifyCredentials(STUB_CONFIGURATION, context, OKAPI_DATA);
+    verifyTokenUtils(times(1));
+  }
+
+  @Test
+  public void shouldStoreVerifiedConfigurationInCache1() throws ExecutionException, InterruptedException {
+    when(configService.verifyCredentials(STUB_CONFIGURATION, context, OKAPI_DATA)).thenReturn(completedFuture(emptyList()));
+    when(TokenUtils.fetchUserInfo(OKAPI_DATA.getApiToken()))
+      .thenReturn(FutureUtils.failedFuture(new RuntimeException("EXCEPTION")));
+
+    List<ConfigurationError> errors = cacheService.verifyCredentials(STUB_CONFIGURATION, context, OKAPI_DATA).get();
+
+    assertThat(errors, hasSize(1));
+    assertThat(errors.get(0).getMessage(), containsString("EXCEPTION"));
+    assertThat(testCache.getValue(STUB_USER_INFO.getUserId()), nullValue());
+
+    verify(configService).verifyCredentials(STUB_CONFIGURATION, context, OKAPI_DATA);
+    verifyTokenUtils(times(1));
+  }
+
+  private static void verifyTokenUtils(VerificationMode verificationMode) {
+    verifyStatic(TokenUtils.class, verificationMode);
+    TokenUtils.fetchUserInfo(OKAPI_DATA.getApiToken());
+  }
 }

--- a/src/test/java/org/folio/holdingsiq/service/config/ConfigurationServiceCacheTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/config/ConfigurationServiceCacheTest.java
@@ -134,7 +134,7 @@ public class ConfigurationServiceCacheTest {
   }
 
   @Test
-  public void shouldStoreVerifiedConfigurationInCache1() throws ExecutionException, InterruptedException {
+  public void shouldReturnTokenExceptionAsVerificationError() throws ExecutionException, InterruptedException {
     when(configService.verifyCredentials(STUB_CONFIGURATION, context, OKAPI_DATA)).thenReturn(completedFuture(emptyList()));
     when(TokenUtils.fetchUserInfo(OKAPI_DATA.getApiToken()))
       .thenReturn(FutureUtils.failedFuture(new RuntimeException("EXCEPTION")));

--- a/src/test/java/org/folio/holdingsiq/service/config/RMAPIConfigurationServiceTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/config/RMAPIConfigurationServiceTest.java
@@ -1,50 +1,87 @@
 package org.folio.holdingsiq.service.config;
 
-import static org.folio.holdingsiq.service.config.ConfigTestData.OKAPI_DATA;
+import static io.vertx.core.Future.succeededFuture;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
-import org.folio.holdingsiq.model.Configuration;
-import org.folio.holdingsiq.service.impl.ConfigurationClientProvider;
-import org.folio.holdingsiq.service.impl.ConfigurationServiceImpl;
-import org.folio.rest.client.ConfigurationsClient;
-import org.folio.rest.jaxrs.model.Config;
-import org.folio.rest.jaxrs.model.Configs;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.folio.holdingsiq.model.Configuration;
+import org.folio.holdingsiq.model.OkapiData;
+import org.folio.holdingsiq.service.impl.ConfigurationServiceImpl;
+import org.folio.rest.jaxrs.model.Config;
 
-import io.vertx.core.Handler;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.buffer.impl.BufferImpl;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.impl.HttpClientResponseImpl;
-
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(WebClient.class)
+@PowerMockIgnore({"org.apache.logging.log4j.*"})
+// the above added due to the issue:
+// https://github.com/powermock/powermock/issues/861
 public class RMAPIConfigurationServiceTest {
 
-  private ConfigurationClientProvider configurationClientProvider = mock(ConfigurationClientProvider.class);
-  private ConfigurationsClient mockConfigurationsClient = mock(ConfigurationsClient.class);
-  private ConfigurationServiceImpl configurationService = new ConfigurationServiceImpl(configurationClientProvider);
+  @Mock
+  private Vertx vertx;
+  @Mock
+  private WebClient webClient;
+  @Mock
+  private HttpResponse<Buffer> httpResponse;
+  @Mock
+  private HttpRequest<Buffer> httpRequest;
+  private ConfigurationServiceImpl service;
 
   @Before
   public void setUp() {
-    when(configurationClientProvider.createClient(anyString(), anyInt(), anyString(), anyString())).thenReturn(mockConfigurationsClient);
+    initMocks(this);
+
+    mockStatic(WebClient.class);
+    when(WebClient.create(vertx)).thenReturn(webClient);
+
+    service = new ConfigurationServiceImpl(vertx);
   }
 
   @Test
+  public void shouldFailIfResponseIsNotOk() {
+    when(webClient.get(anyInt(), any(), any())).thenReturn(httpRequest);
+
+    when(httpRequest.putHeader(anyString(), (String) any())).thenReturn(httpRequest);
+    when(httpRequest.expect(any())).thenReturn(httpRequest);
+    doAnswer(httpResponseAnswer(httpResponse)).when(httpRequest).send(any());
+
+    when(httpResponse.statusCode()).thenReturn(500);
+    when(httpResponse.toString()).thenReturn("failure");
+
+    OkapiData okapiData = mock(OkapiData.class);
+
+    CompletableFuture<Configuration> result = service.retrieveConfiguration(okapiData);
+
+    assertTrue(result.isCompletedExceptionally());
+  }
+
+  /*@Test
   public void shouldCompleteExceptionallyWhenRequestFails() throws Exception {
     HttpClientResponse response = mock(HttpClientResponseImpl.class);
     when(response.statusCode()).thenReturn(400);
@@ -89,6 +126,12 @@ public class RMAPIConfigurationServiceTest {
 
     CompletableFuture<Configuration> future = configurationService.updateConfiguration(Configuration.builder().build(), OKAPI_DATA);
     assertTrue(future.isCompletedExceptionally());
+  }*/
+
+  private static <T> GenericHandlerAnswer<AsyncResult<HttpResponse<T>>, Void> httpResponseAnswer(
+      HttpResponse<T> httpResponse) {
+    AsyncResult<HttpResponse<T>> res = succeededFuture(httpResponse);
+    return new GenericHandlerAnswer<>(res, 0);
   }
 
   private Config createConfig(String code) {
@@ -128,6 +171,30 @@ public class RMAPIConfigurationServiceTest {
     public Object answer(InvocationOnMock invocation) {
       ((Handler<HttpClientResponse>) invocation.getArgument(handlerArgumentIndex)).handle(response);
       return null;
+    }
+  }
+
+  static class GenericHandlerAnswer<H, R> implements Answer<R> {
+
+    private final H handlerResult;
+    private final int argumentIndex;
+    private R returnResult;
+
+    public GenericHandlerAnswer(H handlerResult, int handlerArgumentIndex) {
+      this.handlerResult = handlerResult;
+      this.argumentIndex = handlerArgumentIndex;
+    }
+
+    public GenericHandlerAnswer(H handlerResult, int handlerArgumentIndex, R returnResult) {
+      this(handlerResult, handlerArgumentIndex);
+      this.returnResult = returnResult;
+    }
+
+    @Override
+    public R answer(InvocationOnMock invocation) {
+      Handler<H> handler = invocation.getArgument(argumentIndex);
+      handler.handle(handlerResult);
+      return returnResult;
     }
   }
 }

--- a/src/test/java/org/folio/holdingsiq/service/config/RMAPIConfigurationServiceTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/config/RMAPIConfigurationServiceTest.java
@@ -1,26 +1,36 @@
 package org.folio.holdingsiq.service.config;
 
 import static io.vertx.core.Future.succeededFuture;
+import static org.apache.http.HttpHeaders.ACCEPT;
+import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
+import static org.folio.holdingsiq.service.config.ConfigTestData.OKAPI_DATA;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,9 +42,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import org.folio.holdingsiq.model.Configuration;
-import org.folio.holdingsiq.model.OkapiData;
 import org.folio.holdingsiq.service.impl.ConfigurationServiceImpl;
-import org.folio.rest.jaxrs.model.Config;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(WebClient.class)
@@ -42,6 +50,15 @@ import org.folio.rest.jaxrs.model.Config;
 // the above added due to the issue:
 // https://github.com/powermock/powermock/issues/861
 public class RMAPIConfigurationServiceTest {
+
+  private static final String JSON_API_TYPE = "application/vnd.api+json";
+  private static final String USER_CREDS_URL = "/eholdings/user-kb-credential";
+
+  private static final String USER_CRED_ID = "8d5b862b-9fb3-411d-afa7-406151739d26";
+  private static final String USER_CRED_NAME = "University of Massachusetts";
+  private static final String USER_CRED_APIKEY = "APIKEY";
+  private static final String USER_CRED_CUSTOMERID = "CUSTID";
+  private static final String USER_CRED_URL = "URL";
 
   @Mock
   private Vertx vertx;
@@ -64,128 +81,171 @@ public class RMAPIConfigurationServiceTest {
   }
 
   @Test
-  public void shouldFailIfResponseIsNotOk() {
-    when(webClient.get(anyInt(), any(), any())).thenReturn(httpRequest);
+  public void shouldReturnConfiguration() throws ExecutionException, InterruptedException {
+    mockCredentialsRequest();
 
-    when(httpRequest.putHeader(anyString(), (String) any())).thenReturn(httpRequest);
-    when(httpRequest.expect(any())).thenReturn(httpRequest);
-    doAnswer(httpResponseAnswer(httpResponse)).when(httpRequest).send(any());
+    when(httpResponse.statusCode()).thenReturn(SC_OK);
+    when(httpResponse.bodyAsJsonObject()).thenReturn(CredentialsBuilder.instance()
+      .id(USER_CRED_ID)
+      .name(USER_CRED_NAME)
+      .apiKey(USER_CRED_APIKEY)
+      .customerId(USER_CRED_CUSTOMERID)
+      .url(USER_CRED_URL)
+      .build());
 
-    when(httpResponse.statusCode()).thenReturn(500);
+    CompletableFuture<Configuration> result = service.retrieveConfiguration(OKAPI_DATA);
+
+    Configuration conf = result.get();
+
+    assertNotNull(conf);
+    assertEquals(USER_CRED_CUSTOMERID, conf.getCustomerId());
+    assertEquals(USER_CRED_APIKEY, conf.getApiKey());
+    assertEquals(USER_CRED_URL, conf.getUrl());
+
+    verifyCredentialsRequest();
+  }
+
+  @Test
+  public void shouldReturnPartiallyInitializedConfiguration() throws ExecutionException, InterruptedException {
+    mockCredentialsRequest();
+
+    when(httpResponse.statusCode()).thenReturn(SC_OK);
+    when(httpResponse.bodyAsJsonObject()).thenReturn(CredentialsBuilder.instance()
+      .id(USER_CRED_ID)
+      .name(USER_CRED_NAME)
+      .customerId(USER_CRED_CUSTOMERID)
+      .build());
+
+    CompletableFuture<Configuration> result = service.retrieveConfiguration(OKAPI_DATA);
+
+    Configuration conf = result.get();
+
+    assertNotNull(conf);
+    assertEquals(USER_CRED_CUSTOMERID, conf.getCustomerId());
+    assertNull(USER_CRED_APIKEY, conf.getApiKey());
+    assertNull(USER_CRED_URL, conf.getUrl());
+
+    verifyCredentialsRequest();
+  }
+
+  @Test
+  public void shouldFailIfUserCredentialsResponseIsNotOk() {
+    mockCredentialsRequest();
+
+    when(httpResponse.statusCode()).thenReturn(SC_INTERNAL_SERVER_ERROR);
     when(httpResponse.toString()).thenReturn("failure");
 
-    OkapiData okapiData = mock(OkapiData.class);
-
-    CompletableFuture<Configuration> result = service.retrieveConfiguration(okapiData);
+    CompletableFuture<Configuration> result = service.retrieveConfiguration(OKAPI_DATA);
 
     assertTrue(result.isCompletedExceptionally());
+
+    verifyCredentialsRequest();
   }
 
-  /*@Test
-  public void shouldCompleteExceptionallyWhenRequestFails() throws Exception {
-    HttpClientResponse response = mock(HttpClientResponseImpl.class);
-    when(response.statusCode()).thenReturn(400);
-    when(response.bodyHandler(any())).thenAnswer(new HandleBodyAnswer(new BufferImpl()));
-    doAnswer(new HandleResponseAnswer(response, 5))
-      .when(mockConfigurationsClient).getEntries(anyString(), anyInt(), anyInt(), any(), any(), any());
-    CompletableFuture<Configuration> future = configurationService.retrieveConfiguration(OKAPI_DATA);
-    assertTrue(future.isCompletedExceptionally());
+  private void verifyCredentialsRequest() {
+    verify(webClient).get(OKAPI_DATA.getOkapiPort(), OKAPI_DATA.getOkapiHost(), USER_CREDS_URL);
+    verify(httpRequest).putHeader(OKAPI_HEADER_TENANT, OKAPI_DATA.getTenant());
+    verify(httpRequest).putHeader(OKAPI_HEADER_TOKEN, OKAPI_DATA.getApiToken());
+    verify(httpRequest).putHeader(ACCEPT, JSON_API_TYPE);
+    verify(httpRequest).send(any());
   }
 
-  @Test
-  public void shouldCompleteExceptionallyWhenHttpClientThrowsException() throws Exception {
-    doThrow(new UnsupportedEncodingException()).when(mockConfigurationsClient)
-      .getEntries(anyString(), anyInt(), anyInt(), any(), any(), any());
-    CompletableFuture<Configuration> future = configurationService.retrieveConfiguration(OKAPI_DATA);
-    assertTrue(future.isCompletedExceptionally());
+  private void mockCredentialsRequest() {
+    when(webClient.get(OKAPI_DATA.getOkapiPort(), OKAPI_DATA.getOkapiHost(), USER_CREDS_URL)).thenReturn(httpRequest);
+
+    when(httpRequest.putHeader(OKAPI_HEADER_TENANT, OKAPI_DATA.getTenant())).thenReturn(httpRequest);
+    when(httpRequest.putHeader(OKAPI_HEADER_TOKEN, OKAPI_DATA.getApiToken())).thenReturn(httpRequest);
+    when(httpRequest.putHeader(ACCEPT, JSON_API_TYPE)).thenReturn(httpRequest);
+    when(httpRequest.expect(any())).thenReturn(httpRequest);
+    doAnswer(httpResponseAnswer(httpResponse)).when(httpRequest).send(any());
   }
 
-  @Test
-  public void shouldCompleteExceptionallyWhenDeleteRequestFails() throws Exception {
-    HttpClientResponse getResponse = mock(HttpClientResponseImpl.class);
-    HttpClientResponse deleteResponse = mock(HttpClientResponseImpl.class);
-
-    Configs configs = new Configs().withConfigs(Arrays.asList(
-      createConfig("kb.ebsco.url"),
-      createConfig("kb.ebsco.customerId"),
-      createConfig("kb.ebsco.apiKey")
-    ));
-
-    ObjectMapper mapper = new ObjectMapper();
-    BufferImpl buffer = new BufferImpl();
-    buffer.appendString(mapper.writeValueAsString(configs));
-    when(getResponse.statusCode()).thenReturn(200);
-    when(deleteResponse.statusCode()).thenReturn(400);
-    when(getResponse.bodyHandler(any())).thenAnswer(new HandleBodyAnswer(buffer));
-    when(deleteResponse.bodyHandler(any())).thenAnswer(new HandleBodyAnswer(new BufferImpl()));
-
-    doAnswer(new HandleResponseAnswer(getResponse, 5))
-      .when(mockConfigurationsClient).getEntries(anyString(), anyInt(), anyInt(), any(), any(), any());
-    doAnswer(new HandleResponseAnswer(deleteResponse, 2))
-      .when(mockConfigurationsClient).deleteEntryId(any(), any(), any());
-
-    CompletableFuture<Configuration> future = configurationService.updateConfiguration(Configuration.builder().build(), OKAPI_DATA);
-    assertTrue(future.isCompletedExceptionally());
-  }*/
-
-  private static <T> GenericHandlerAnswer<AsyncResult<HttpResponse<T>>, Void> httpResponseAnswer(
+  private static <T> HandlerAnswer<AsyncResult<HttpResponse<T>>, Void> httpResponseAnswer(
       HttpResponse<T> httpResponse) {
     AsyncResult<HttpResponse<T>> res = succeededFuture(httpResponse);
-    return new GenericHandlerAnswer<>(res, 0);
+    return new HandlerAnswer<>(res, 0);
   }
 
-  private Config createConfig(String code) {
-    return new Config()
-      .withModule("EKB")
-      .withConfigName("api_access")
-      .withCode(code)
-      .withDescription("description")
-      .withEnabled(true)
-      .withValue("value");
+  private static class CredentialsBuilder {
+
+    private final JsonObject creds;
+
+    static CredentialsBuilder instance() {
+      return new CredentialsBuilder();
+    }
+
+    private CredentialsBuilder() {
+      creds = new JsonObject();
+    }
+
+    CredentialsBuilder id(String id) {
+      if (StringUtils.isNotBlank(id)) {
+        creds.put("id", id);
+      }
+
+      return this;
+    }
+
+    CredentialsBuilder name(String name) {
+      if (StringUtils.isNotBlank(name)) {
+        attributes().put("name", name);
+      }
+
+      return this;
+    }
+
+    CredentialsBuilder apiKey(String apiKey) {
+      if (StringUtils.isNotBlank(apiKey)) {
+        attributes().put("apiKey", apiKey);
+      }
+
+      return this;
+    }
+
+    CredentialsBuilder url(String url) {
+      if (StringUtils.isNotBlank(url)) {
+        attributes().put("url", url);
+      }
+
+      return this;
+    }
+
+    CredentialsBuilder customerId(String customerId) {
+      if (StringUtils.isNotBlank(customerId)) {
+        attributes().put("customerId", customerId);
+      }
+
+      return this;
+    }
+
+    JsonObject build() {
+      return creds;
+    }
+
+    private JsonObject attributes() {
+      JsonObject attrs = creds.getJsonObject("attributes");
+
+      if (attrs == null) {
+        attrs = new JsonObject();
+        creds.put("attributes", attrs);
+      }
+
+      return attrs;
+    }
   }
 
-  private class HandleBodyAnswer implements Answer<Object> {
-    private Buffer body;
-
-    HandleBodyAnswer(Buffer body) {
-      this.body = body;
-    }
-
-    @Override
-    public Object answer(InvocationOnMock invocation) {
-      ((Handler<Buffer>) invocation.getArgument(0)).handle(body);
-      return invocation.getMock();
-    }
-  }
-
-  private class HandleResponseAnswer implements Answer<Object> {
-    private HttpClientResponse response;
-    private int handlerArgumentIndex;
-
-    HandleResponseAnswer(HttpClientResponse response, int handlerArgumentIndex) {
-      this.response = response;
-      this.handlerArgumentIndex = handlerArgumentIndex;
-    }
-
-    @Override
-    public Object answer(InvocationOnMock invocation) {
-      ((Handler<HttpClientResponse>) invocation.getArgument(handlerArgumentIndex)).handle(response);
-      return null;
-    }
-  }
-
-  static class GenericHandlerAnswer<H, R> implements Answer<R> {
+  private static class HandlerAnswer<H, R> implements Answer<R> {
 
     private final H handlerResult;
     private final int argumentIndex;
     private R returnResult;
 
-    public GenericHandlerAnswer(H handlerResult, int handlerArgumentIndex) {
+    public HandlerAnswer(H handlerResult, int handlerArgumentIndex) {
       this.handlerResult = handlerResult;
       this.argumentIndex = handlerArgumentIndex;
     }
 
-    public GenericHandlerAnswer(H handlerResult, int handlerArgumentIndex, R returnResult) {
+    public HandlerAnswer(H handlerResult, int handlerArgumentIndex, R returnResult) {
       this(handlerResult, handlerArgumentIndex);
       this.returnResult = returnResult;
     }

--- a/src/test/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceImplTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceImplTest.java
@@ -2,7 +2,6 @@ package org.folio.holdingsiq.service.impl;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
@@ -12,7 +11,7 @@ import static org.folio.holdingsiq.service.util.TestUtil.mockResponseForUpdateAn
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonParser;
 import io.vertx.core.json.Json;
 import org.apache.http.HttpStatus;
 import org.junit.After;
@@ -44,8 +43,8 @@ public class HoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig {
   }
 
   @Test
-  public void testRetrieveProxies() throws JsonProcessingException {
-    doReturn(null).when(Json.mapper).readValue(anyString(), any(Class.class));
+  public void testRetrieveProxies() throws IOException {
+    doReturn(null).when(Json.mapper).readValue(any(JsonParser.class), any(Class.class));
     mockResponse(mockResponseBody, mockResponse, "{}", HttpStatus.SC_OK);
     CompletableFuture<Proxies> completableFuture = service.retrieveProxies();
 

--- a/src/test/java/org/folio/holdingsiq/service/impl/PackagesHoldingsIQServiceImplTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/PackagesHoldingsIQServiceImplTest.java
@@ -1,27 +1,28 @@
 package org.folio.holdingsiq.service.impl;
 
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+import static org.folio.holdingsiq.service.util.TestUtil.mockResponse;
+import static org.folio.holdingsiq.service.util.TestUtil.mockResponseForUpdateAndCreate;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import com.fasterxml.jackson.core.JsonParser;
 import io.vertx.core.json.Json;
 import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import org.folio.holdingsiq.model.PackageByIdData;
 import org.folio.holdingsiq.model.PackagePut;
 import org.folio.holdingsiq.model.Packages;
 import org.folio.holdingsiq.model.Sort;
 import org.folio.holdingsiq.service.PackagesHoldingsIQService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
-
-import static org.folio.holdingsiq.service.util.TestUtil.mockResponse;
-import static org.folio.holdingsiq.service.util.TestUtil.mockResponseForUpdateAndCreate;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class PackagesHoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig {
 
@@ -94,7 +95,7 @@ public class PackagesHoldingsIQServiceImplTest extends HoldingsIQServiceTestConf
   public void testPostPackage() throws IOException {
     mockResponse(mockResponseBody, mockResponse, "{}", HttpStatus.SC_OK);
 
-    doReturn(packageCreated).when(Json.mapper).readValue(anyString(), any(Class.class));
+    doReturn(packageCreated).when(Json.mapper).readValue(any(JsonParser.class), any(Class.class));
     CompletableFuture<PackageByIdData> completableFuture = packagesHoldingsIQService.postPackage(packagePost, VENDOR_ID);
 
     assertTrue(isCompletedNormally(completableFuture));

--- a/src/test/java/org/folio/holdingsiq/service/impl/ProviderHoldingsIQServiceImplTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/ProviderHoldingsIQServiceImplTest.java
@@ -1,29 +1,28 @@
 package org.folio.holdingsiq.service.impl;
 
-import io.vertx.core.json.Json;
-import org.apache.http.HttpStatus;
-import org.folio.holdingsiq.model.Sort;
-import org.folio.holdingsiq.model.VendorById;
-import org.folio.holdingsiq.model.Vendors;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import static org.folio.holdingsiq.service.util.TestUtil.mockResponse;
+import static org.folio.holdingsiq.service.util.TestUtil.mockResponseForUpdateAndCreate;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
-import static org.folio.holdingsiq.service.util.TestUtil.mockResponse;
-import static org.folio.holdingsiq.service.util.TestUtil.mockResponseForUpdateAndCreate;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonParser;
+import io.vertx.core.json.Json;
+import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.folio.holdingsiq.model.Sort;
+import org.folio.holdingsiq.model.VendorById;
+import org.folio.holdingsiq.model.Vendors;
 
 public class ProviderHoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig {
 
@@ -43,7 +42,7 @@ public class ProviderHoldingsIQServiceImplTest extends HoldingsIQServiceTestConf
   @Test
   public void testGetVendorId() throws IOException {
     mockResponse(mockResponseBody, mockResponse, "{}", HttpStatus.SC_OK);
-    doReturn(rootProxyCustomLabels).when(Json.mapper).readValue(anyString(), any(Class.class));
+    doReturn(rootProxyCustomLabels).when(Json.mapper).readValue(any(JsonParser.class), any(Class.class));
     CompletableFuture<Long> completableFuture = providerHoldingsIQService.getVendorId();
 
     assertTrue(isCompletedNormally(completableFuture));
@@ -79,9 +78,9 @@ public class ProviderHoldingsIQServiceImplTest extends HoldingsIQServiceTestConf
   }
 
   @Test
-  public void testRetrieveVendorsCompleteExceptionallyWhenThrowServiceException() throws JsonProcessingException {
+  public void testRetrieveVendorsCompleteExceptionallyWhenThrowServiceException() throws IOException {
     mockResponse(mockResponseBody, mockResponse, "{}", HttpStatus.SC_OK);
-    doThrow(JsonParseException.class).when(Json.mapper).readValue(anyString(), any(Class.class));
+    doThrow(JsonParseException.class).when(Json.mapper).readValue(any(JsonParser.class), any(Class.class));
 
     CompletableFuture<Vendors> future = providerHoldingsIQService.retrieveProviders("Busket",
       PAGE_FOR_PARAM, COUNT_FOR_PARAM, Sort.NAME);

--- a/src/test/java/org/folio/holdingsiq/service/impl/TitlesHoldingsIQServiceImplTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/TitlesHoldingsIQServiceImplTest.java
@@ -1,26 +1,27 @@
 package org.folio.holdingsiq.service.impl;
 
-import io.vertx.core.json.Json;
-import org.apache.http.HttpStatus;
-import org.folio.holdingsiq.model.Sort;
-import org.folio.holdingsiq.model.Title;
-import org.folio.holdingsiq.model.Titles;
-import org.folio.holdingsiq.service.TitlesHoldingsIQService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+import static org.folio.holdingsiq.service.util.TestUtil.mockResponse;
+import static org.folio.holdingsiq.service.util.TestUtil.mockResponseForUpdateAndCreate;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
-import static org.folio.holdingsiq.service.util.TestUtil.mockResponse;
-import static org.folio.holdingsiq.service.util.TestUtil.mockResponseForUpdateAndCreate;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import com.fasterxml.jackson.core.JsonParser;
+import io.vertx.core.json.Json;
+import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.folio.holdingsiq.model.Sort;
+import org.folio.holdingsiq.model.Title;
+import org.folio.holdingsiq.model.Titles;
+import org.folio.holdingsiq.service.TitlesHoldingsIQService;
 
 public class TitlesHoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig {
 
@@ -40,7 +41,7 @@ public class TitlesHoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig
   @Test
   public void testRetrieveTitles() throws IOException {
     mockResponse(mockResponseBody, mockResponse, "{}", HttpStatus.SC_OK);
-    doReturn(titles).when(Json.mapper).readValue(anyString(), any(Class.class));
+    doReturn(titles).when(Json.mapper).readValue(any(JsonParser.class), any(Class.class));
 
     CompletableFuture<Titles> completableFuture = titlesHoldingsIQService.retrieveTitles(filterQuery, Sort.NAME,
       PAGE_FOR_PARAM, COUNT_FOR_PARAM);
@@ -54,7 +55,7 @@ public class TitlesHoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig
   @Test
   public void testRetrieveTitlesWithVendorId() throws IOException {
     mockResponse(mockResponseBody, mockResponse, "{}", HttpStatus.SC_OK);
-    doReturn(titles).when(Json.mapper).readValue(anyString(), any(Class.class));
+    doReturn(titles).when(Json.mapper).readValue(any(JsonParser.class), any(Class.class));
 
     CompletableFuture<Titles> completableFuture = titlesHoldingsIQService.retrieveTitles(VENDOR_ID, PACKAGE_ID, filterQuery,
       Sort.NAME, PAGE_FOR_PARAM, COUNT_FOR_PARAM);
@@ -79,7 +80,7 @@ public class TitlesHoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig
   public void testPostTitle() throws IOException {
     mockResponseForUpdateAndCreate(mockResponseBody, mockResponse, "{}", HttpStatus.SC_OK, HttpStatus.SC_OK);
 
-    doReturn(titleCreated).when(Json.mapper).readValue(anyString(), any(Class.class));
+    doReturn(titleCreated).when(Json.mapper).readValue(any(JsonParser.class), any(Class.class));
     CompletableFuture<Title> completableFuture = titlesHoldingsIQService.postTitle(titlePost, packageId);
 
     assertTrue(isCompletedNormally(completableFuture));


### PR DESCRIPTION
## Purpose
Modify configuration service so that it gets configuration settings from eHoldings. Store cached configuration per user (userId)

## Approach
* implement configuration retrieval from eHoldings
* remove `updateConfiguration()` method from `ConfigurationService`
* extract userId from OKAPI token and use it as a key to store cached configuration

