### PR TITLE
MODKBEKBJ-505 Log responses from HoldingsIQ/MODKBEKBJ

### DIFF
--- a/src/main/java/org/folio/holdingsiq/model/Configuration.java
+++ b/src/main/java/org/folio/holdingsiq/model/Configuration.java
@@ -9,11 +9,11 @@ import lombok.Value;
  */
 @Value
 @Builder(toBuilder = true)
-public final class Configuration implements Shareable {
+public class Configuration implements Shareable {
 
-  private final String customerId;
-  private final String apiKey;
-  private final String url;
-  private final Boolean configValid;
+  String customerId;
+  String apiKey;
+  String url;
+  Boolean configValid;
 
 }

--- a/src/main/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceImpl.java
@@ -1,5 +1,7 @@
 package org.folio.holdingsiq.service.impl;
 
+import static org.folio.holdingsiq.service.impl.HoldingsRequestHelper.successBodyLogger;
+
 import java.util.concurrent.CompletableFuture;
 
 import io.vertx.core.Vertx;
@@ -11,10 +13,11 @@ import org.folio.holdingsiq.service.HoldingsIQService;
 
 public class HoldingsIQServiceImpl implements HoldingsIQService {
 
-  private HoldingsRequestHelper holdingsRequestHelper;
+  private final HoldingsRequestHelper holdingsRequestHelper;
 
   public HoldingsIQServiceImpl(Configuration config, Vertx vertx) {
     holdingsRequestHelper = new HoldingsRequestHelper(config, vertx);
+    holdingsRequestHelper.addBodyListener(successBodyLogger());
   }
 
   @Override

--- a/src/main/java/org/folio/holdingsiq/service/impl/HoldingsInteractionContext.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/HoldingsInteractionContext.java
@@ -1,0 +1,54 @@
+package org.folio.holdingsiq.service.impl;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import lombok.Value;
+
+@Value
+public class HoldingsInteractionContext {
+
+  String requestUrl;
+  Class<?> expectedResultClass;
+
+  HttpClientRequest request;
+  HttpClientResponse response;
+
+
+  public HttpMethod httpMethod() {
+    return request.method();
+  }
+
+  public String absoluteURI() {
+    return request.absoluteURI();
+  }
+
+  public String uri() {
+    return request.uri();
+  }
+
+  public String path() {
+    return request.path();
+  }
+
+  public String query() {
+    return request.query();
+  }
+
+  public MultiMap requestHeaders() {
+    return request.headers();
+  }
+
+  public MultiMap responseHeaders() {
+    return response.headers();
+  }
+
+  public int statusCode() {
+    return response.statusCode();
+  }
+
+  public String statusMessage() {
+    return response.statusMessage();
+  }
+}

--- a/src/main/java/org/folio/holdingsiq/service/impl/HoldingsRequestHelper.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/HoldingsRequestHelper.java
@@ -213,20 +213,14 @@ class HoldingsRequestHelper {
   }
 
   static HoldingsResponseBodyListener successBodyLogger() {
-    return new SuccessfulResponseBodyLogger();
-  }
-
-  private static class SuccessfulResponseBodyLogger implements HoldingsResponseBodyListener {
-
-    @Override
-    public void bodyReceived(Buffer body, HoldingsInteractionContext ctx) {
+    return (body, ctx) -> {
       int sc = ctx.statusCode();
 
       if (sc == 200 || sc == 201 || sc == 202 || sc == 204) {
-        LOG.info("[OK] RMAPI Service response: method = [{}], statusCode = [{}], body = [{}]",
-            ctx.httpMethod(), ctx.statusCode(), body.toString());
+        LOG.info("[OK] RMAPI Service response: query = [{}], method = [{}], statusCode = [{}], body = [{}]",
+            ctx.getRequestUrl(), ctx.httpMethod(), sc, body.toString());
       }
-    }
-
+    };
   }
+
 }

--- a/src/main/java/org/folio/holdingsiq/service/impl/HoldingsResponseBodyListener.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/HoldingsResponseBodyListener.java
@@ -1,0 +1,8 @@
+package org.folio.holdingsiq.service.impl;
+
+import io.vertx.core.buffer.Buffer;
+
+public interface HoldingsResponseBodyListener {
+
+  void bodyReceived(Buffer body, HoldingsInteractionContext ctx);
+}

--- a/src/main/java/org/folio/holdingsiq/service/impl/PackagesHoldingsIQServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/PackagesHoldingsIQServiceImpl.java
@@ -2,6 +2,7 @@ package org.folio.holdingsiq.service.impl;
 
 import static org.folio.holdingsiq.service.impl.HoldingsRequestHelper.PACKAGES_PATH;
 import static org.folio.holdingsiq.service.impl.HoldingsRequestHelper.VENDORS_PATH;
+import static org.folio.holdingsiq.service.impl.HoldingsRequestHelper.successBodyLogger;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -21,10 +22,11 @@ import org.folio.holdingsiq.service.impl.urlbuilder.PackagesFilterableUrlBuilder
 
 public class PackagesHoldingsIQServiceImpl implements PackagesHoldingsIQService {
 
-  private HoldingsRequestHelper holdingsRequestHelper;
+  private final HoldingsRequestHelper holdingsRequestHelper;
 
   public PackagesHoldingsIQServiceImpl(Configuration config, Vertx vertx) {
     holdingsRequestHelper = new HoldingsRequestHelper(config, vertx);
+    holdingsRequestHelper.addBodyListener(successBodyLogger());
   }
 
   @Override

--- a/src/main/java/org/folio/holdingsiq/service/impl/ProviderHoldingsIQServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/ProviderHoldingsIQServiceImpl.java
@@ -1,6 +1,7 @@
 package org.folio.holdingsiq.service.impl;
 
 import static org.folio.holdingsiq.service.impl.HoldingsRequestHelper.VENDORS_PATH;
+import static org.folio.holdingsiq.service.impl.HoldingsRequestHelper.successBodyLogger;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -18,16 +19,20 @@ import org.folio.holdingsiq.service.impl.urlbuilder.QueryableUrlBuilder;
 public class ProviderHoldingsIQServiceImpl implements ProviderHoldingsIQService {
 
   private static final String VENDOR_NAME_PARAMETER = "vendorname";
-  private HoldingsIQService holdingsIQService;
-  private HoldingsRequestHelper holdingsRequestHelper;
+  private final HoldingsIQService holdingsIQService;
+  private final HoldingsRequestHelper holdingsRequestHelper;
 
   public ProviderHoldingsIQServiceImpl(Configuration config, Vertx vertx, HoldingsIQService holdingsIQService) {
     holdingsRequestHelper = new HoldingsRequestHelper(config, vertx);
+    holdingsRequestHelper.addBodyListener(successBodyLogger());
+
     this.holdingsIQService = holdingsIQService;
   }
 
   public ProviderHoldingsIQServiceImpl(Configuration config, Vertx vertx) {
     holdingsRequestHelper = new HoldingsRequestHelper(config, vertx);
+    holdingsRequestHelper.addBodyListener(successBodyLogger());
+
     this.holdingsIQService = new HoldingsIQServiceImpl(config, vertx);
   }
 

--- a/src/main/java/org/folio/holdingsiq/service/impl/ResourcesHoldingsIQServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/ResourcesHoldingsIQServiceImpl.java
@@ -5,6 +5,7 @@ import static java.lang.String.format;
 import static org.folio.holdingsiq.service.impl.HoldingsRequestHelper.PACKAGES_PATH;
 import static org.folio.holdingsiq.service.impl.HoldingsRequestHelper.TITLES_PATH;
 import static org.folio.holdingsiq.service.impl.HoldingsRequestHelper.VENDORS_PATH;
+import static org.folio.holdingsiq.service.impl.HoldingsRequestHelper.successBodyLogger;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -21,10 +22,11 @@ import org.folio.holdingsiq.service.ResourcesHoldingsIQService;
 public class ResourcesHoldingsIQServiceImpl implements ResourcesHoldingsIQService {
 
   private static final String RESOURCE_ENDPOINT_FORMAT = "vendors/%s/packages/%s/titles/%s";
-  private HoldingsRequestHelper holdingsRequestHelper;
+  private final HoldingsRequestHelper holdingsRequestHelper;
 
   public ResourcesHoldingsIQServiceImpl(Configuration config, Vertx vertx) {
     holdingsRequestHelper = new HoldingsRequestHelper(config, vertx);
+    holdingsRequestHelper.addBodyListener(successBodyLogger());
   }
 
   @Override

--- a/src/main/java/org/folio/holdingsiq/service/impl/TitlesHoldingsIQServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/TitlesHoldingsIQServiceImpl.java
@@ -5,6 +5,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.holdingsiq.service.impl.HoldingsRequestHelper.PACKAGES_PATH;
 import static org.folio.holdingsiq.service.impl.HoldingsRequestHelper.TITLES_PATH;
 import static org.folio.holdingsiq.service.impl.HoldingsRequestHelper.VENDORS_PATH;
+import static org.folio.holdingsiq.service.impl.HoldingsRequestHelper.successBodyLogger;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -26,10 +27,11 @@ import org.folio.holdingsiq.service.impl.urlbuilder.TitlesFilterableUrlBuilder;
 
 public class TitlesHoldingsIQServiceImpl implements TitlesHoldingsIQService {
 
-  private HoldingsRequestHelper holdingsRequestHelper;
+  private final HoldingsRequestHelper holdingsRequestHelper;
 
   public TitlesHoldingsIQServiceImpl(Configuration config, Vertx vertx) {
     holdingsRequestHelper = new HoldingsRequestHelper(config, vertx);
+    holdingsRequestHelper.addBodyListener(successBodyLogger());
   }
 
   @Override

--- a/src/test/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceImplTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceImplTest.java
@@ -1,7 +1,10 @@
 package org.folio.holdingsiq.service.impl;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 import static org.folio.holdingsiq.service.util.TestUtil.mockResponse;
 import static org.folio.holdingsiq.service.util.TestUtil.mockResponseForUpdateAndCreate;
@@ -13,15 +16,35 @@ import org.apache.http.HttpStatus;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import org.folio.holdingsiq.model.Proxies;
 import org.folio.holdingsiq.model.RootProxyCustomLabels;
+import org.folio.holdingsiq.service.HoldingsIQService;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(HoldingsRequestHelper.class)
+@PowerMockIgnore({"org.apache.logging.log4j.*"})
 public class HoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig {
+
+  private HoldingsIQService service;
+
 
   @Before
   public void setUp() throws IOException {
     setUpStep();
+
+    mockStatic(HoldingsRequestHelper.class);
+    HoldingsResponseBodyListener listener = mock(HoldingsResponseBodyListener.class);
+    // replace real logger with fake one to avoid calls to statusCode() method in the real logger
+    // those calls are mocked inside tests, moreover their number is strictly defined. so any excessive calls
+    // lead to test failures. this is a quick solution to the problem and should be revised later
+    when(HoldingsRequestHelper.successBodyLogger()).thenReturn(listener);
+
+    service = new HoldingsIQServiceImpl(CONFIGURATION, mockVertx);
   }
 
   @After

--- a/src/test/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceTestConfig.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceTestConfig.java
@@ -38,7 +38,6 @@ import org.folio.holdingsiq.model.TitleCreated;
 import org.folio.holdingsiq.model.TitlePost;
 import org.folio.holdingsiq.model.Titles;
 import org.folio.holdingsiq.model.VendorPut;
-import org.folio.holdingsiq.service.HoldingsIQService;
 
 public class HoldingsIQServiceTestConfig {
 
@@ -60,7 +59,6 @@ public class HoldingsIQServiceTestConfig {
   protected HttpClientResponse mockResponse = mock(HttpClientResponse.class);
   protected Buffer mockResponseBody = mock(Buffer.class);
   protected MultiMap stubHeaderMap = MultiMap.caseInsensitiveMultiMap();
-  protected HoldingsIQService service = new HoldingsIQServiceImpl(CONFIGURATION, mockVertx);
   protected ArgumentCaptor<String> url = ArgumentCaptor.forClass(String.class);
 
   protected ObjectMapper savedPrettyMapper;

--- a/src/test/java/org/folio/holdingsiq/service/impl/ResourcesHoldingsIQServiceImplTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/ResourcesHoldingsIQServiceImplTest.java
@@ -1,29 +1,50 @@
 package org.folio.holdingsiq.service.impl;
 
-import org.apache.http.HttpStatus;
-import org.folio.holdingsiq.model.ResourceSelectedPayload;
-import org.folio.holdingsiq.model.Title;
-import org.folio.holdingsiq.service.ResourcesHoldingsIQService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+import static org.folio.holdingsiq.service.util.TestUtil.mockResponse;
+import static org.folio.holdingsiq.service.util.TestUtil.mockResponseForUpdateAndCreate;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
-import static org.folio.holdingsiq.service.util.TestUtil.mockResponse;
-import static org.folio.holdingsiq.service.util.TestUtil.mockResponseForUpdateAndCreate;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.verify;
+import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+import org.folio.holdingsiq.model.ResourceSelectedPayload;
+import org.folio.holdingsiq.model.Title;
+import org.folio.holdingsiq.service.ResourcesHoldingsIQService;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(HoldingsRequestHelper.class)
+@PowerMockIgnore({"org.apache.logging.log4j.*"})
 public class ResourcesHoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig {
 
-  private ResourcesHoldingsIQService resourcesHoldingsIQService =
-    new ResourcesHoldingsIQServiceImpl(HoldingsIQServiceImplTest.CONFIGURATION, mockVertx);
+  private ResourcesHoldingsIQService resourcesHoldingsIQService;
+
 
   @Before
   public void setUp() throws IOException {
     setUpStep();
+
+    mockStatic(HoldingsRequestHelper.class);
+    HoldingsResponseBodyListener listener = mock(HoldingsResponseBodyListener.class);
+    // replace real logger with fake one to avoid calls to statusCode() method in the real logger
+    // those calls are mocked inside tests, moreover their number is strictly defined. so any excessive calls
+    // lead to test failures. this is a quick solution to the problem and should be revised later
+    when(HoldingsRequestHelper.successBodyLogger()).thenReturn(listener);
+
+    resourcesHoldingsIQService = new ResourcesHoldingsIQServiceImpl(HoldingsIQServiceImplTest.CONFIGURATION, mockVertx);
   }
 
   @After


### PR DESCRIPTION
## Purpose
Log HoldingsIQ responses for 2xx codes

## Approach
* introduce response body listener to be able to act on response body processing
* create logger as a body listener and record all successful responses with HTTP codes 200, 201, 202, 204

#### TODOS and Open Questions
- [ ] due to the current nature of tests and mocked object it's quite difficult to call real logger in several tests. So to avoid existing test failures the real logger has been replaced with fake one. This has to be revised later to make it possible to call real logger.
