### PR TITLE
FHIQC-10 Load Holdings: Refactor using of Vert.X WebClient

### DIFF
--- a/src/main/java/org/folio/holdingsiq/service/impl/HoldingsInteractionContext.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/HoldingsInteractionContext.java
@@ -1,9 +1,9 @@
 package org.folio.holdingsiq.service.impl;
 
 import io.vertx.core.MultiMap;
-import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.impl.HttpRequestImpl;
 import lombok.Value;
 
@@ -11,7 +11,7 @@ import lombok.Value;
 public class HoldingsInteractionContext {
 
   HttpRequest<?> request;
-  HttpClientResponse response;
+  HttpResponse<?> response;
 
 
   public HttpMethod httpMethod() {

--- a/src/main/java/org/folio/holdingsiq/service/impl/HoldingsRequestHelper.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/HoldingsRequestHelper.java
@@ -4,10 +4,10 @@ import static java.lang.String.format;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import javax.ws.rs.core.HttpHeaders;
@@ -224,7 +224,8 @@ class HoldingsRequestHelper {
 
   private static class WebClientHolder {
 
-    private static final Map<Vertx, WebClient> webClients = new HashMap<>();
+    // in most cases there will be one key-value pair: one vert.x with one web client
+    private static final Map<Vertx, WebClient> webClients = new ConcurrentHashMap<>();
 
 
     static WebClient getClient(Vertx vertx) {

--- a/src/main/java/org/folio/holdingsiq/service/impl/HoldingsRequestHelper.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/HoldingsRequestHelper.java
@@ -224,7 +224,7 @@ class HoldingsRequestHelper {
 
   private static class WebClientHolder {
 
-    // in most cases there will be one key-value pair: one vert.x with one web client
+    // in most cases there will be only one key-value pair in the map: one vert.x with one web client associated
     private static final Map<Vertx, WebClient> webClients = new ConcurrentHashMap<>();
 
 
@@ -232,7 +232,9 @@ class HoldingsRequestHelper {
       return webClients.computeIfAbsent(vertx, vtx -> {
         var webClient = WebClient.create(vtx);
         ((WebClientInternal) webClient).addInterceptor(loggingInterceptor());
-        
+
+        log.info("Web client instance created to serve requests to HoldingsIQ: {}", webClient);
+
         return webClient;
       });
     }


### PR DESCRIPTION
## Purpose
PR addresses an improvement for https://issues.folio.org/browse/FHIQC-10 to optimize usage of Vert.X WebClient by sharing the same instance between requests.

## Approach
* create single web client per vert.x instance and establish association between them to reuse the same web client for the same vert.x. override the default values for HTTP 1/2 connections in web client's pool: 20 and 3 respectively. latter on those settings can be extracted to some external configuration (if needed), like system properties
* move the code to fire "body received" events from interceptor to `onSuccess()` handler of response. for error cases the logging should be handled inside `onFailure()` handler

## Learning

- [Vert.x Web Client documentation](https://vertx.io/docs/vertx-web-client/java/#_creating_a_web_client)
