### PR TITLE
FHIQC-25 Remove usage of PowerMock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,8 @@
 
     <!-- Test dependencies versions   -->
     <junit.version>4.13.2</junit.version>
-    <mockito.version>3.12.4</mockito.version>
+    <mockito.version>4.8.0</mockito.version>
     <wiremock.version>2.27.2</wiremock.version>
-    <powermock.version>2.0.9</powermock.version>
     <awaitility.version>4.2.0</awaitility.version>
 
     <!-- Plugin versions   -->
@@ -123,20 +122,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-inline</artifactId>
       <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/folio/holdingsiq/service/util/TestUtil.java
+++ b/src/test/java/org/folio/holdingsiq/service/util/TestUtil.java
@@ -2,7 +2,14 @@ package org.folio.holdingsiq.service.util;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientResponse;
+import org.folio.util.TokenUtils;
+import org.folio.util.UserInfo;
+import org.mockito.MockedStatic;
+import org.mockito.verification.VerificationMode;
 
+import java.util.concurrent.CompletableFuture;
+
+import static org.folio.holdingsiq.service.config.ConfigTestData.OKAPI_DATA;
 import static org.mockito.Mockito.when;
 
 public final class TestUtil {
@@ -24,5 +31,13 @@ public final class TestUtil {
 
     when(mockResponse.statusCode()).thenReturn(firstStatus).thenReturn(secondStatus);
     when(mockResponseBody.toString()).thenReturn(responseBody);
+  }
+
+  public static void mockUserInfo(MockedStatic<TokenUtils> tokenUtils, CompletableFuture<UserInfo> userInfoFuture) {
+    tokenUtils.when(() -> TokenUtils.fetchUserInfo(OKAPI_DATA.getApiToken())).thenReturn(userInfoFuture);
+  }
+
+  public static void verifyTokenUtils(MockedStatic<TokenUtils> tokenUtils, VerificationMode verificationMode) {
+    tokenUtils.verify(() -> TokenUtils.fetchUserInfo(OKAPI_DATA.getApiToken()), verificationMode);
   }
 }


### PR DESCRIPTION
### Purpose:
Mockito library was updated and start supporting mocking static code (since [3.4.0,](https://github.com/mockito/mockito/releases/tag/v3.4.0)). Which was the only reason we used PowerMock.

### Approach
- Update Mockito version to the last one: [Maven Repository](https://mvnrepository.com/artifact/org.mockito/mockito-core)
- Use mockito-inline 
- Remove usage of PowerMock from the tests dependencies.

### Learning
https://issues.folio.org/browse/FHIQC-25
