### PR TITLE
FHIQC-29 Added Packages Facet to response and new packageidfilter filter

### DIFF
--- a/src/main/java/org/folio/holdingsiq/model/Facets.java
+++ b/src/main/java/org/folio/holdingsiq/model/Facets.java
@@ -1,23 +1,17 @@
 package org.folio.holdingsiq.model;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Value;
 
+import java.util.List;
+
 @Value
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Titles {
+public class Facets {
 
-  @JsonProperty("titles")
-  private List<Title> titleList;
-
-  @JsonProperty("facets")
-  private Facets facets;
-
-  @JsonProperty("totalResults")
-  private Integer totalResults;
+  @JsonProperty("packages")
+  private List<FacetsModel> packages;
 }

--- a/src/main/java/org/folio/holdingsiq/model/FacetsModel.java
+++ b/src/main/java/org/folio/holdingsiq/model/FacetsModel.java
@@ -1,7 +1,5 @@
 package org.folio.holdingsiq.model;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -10,14 +8,14 @@ import lombok.Value;
 @Value
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Titles {
+public class FacetsModel {
 
-  @JsonProperty("titles")
-  private List<Title> titleList;
+  @JsonProperty("id")
+  private Integer packageId;
 
-  @JsonProperty("facets")
-  private Facets facets;
+  @JsonProperty("name")
+  private String packageName;
 
-  @JsonProperty("totalResults")
-  private Integer totalResults;
+  @JsonProperty("count")
+  private Integer totalCount;
 }

--- a/src/main/java/org/folio/holdingsiq/service/TitlesHoldingsIQService.java
+++ b/src/main/java/org/folio/holdingsiq/service/TitlesHoldingsIQService.java
@@ -15,7 +15,8 @@ public interface TitlesHoldingsIQService {
 
   CompletableFuture<Titles> retrieveTitles(String rmapiQuery);
 
-  CompletableFuture<Titles> retrieveTitles(FilterQuery filterQuery, String searchType, Sort sort, int page, int count);
+  CompletableFuture<Titles> retrieveTitles(FilterQuery filterQuery, String searchType, String packageIds,
+                                           Sort sort, int page, int count);
 
   CompletableFuture<Titles> retrieveTitles(Long providerId, Long packageId, FilterQuery filterQuery, String searchType,
                                            Sort sort, int page, int count);

--- a/src/main/java/org/folio/holdingsiq/service/impl/TitlesHoldingsIQServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/TitlesHoldingsIQServiceImpl.java
@@ -48,11 +48,12 @@ public class TitlesHoldingsIQServiceImpl implements TitlesHoldingsIQService {
   }
 
   @Override
-  public CompletableFuture<Titles> retrieveTitles(FilterQuery filterQuery, String searchType, Sort sort, int page,
-                                                  int count) {
+  public CompletableFuture<Titles> retrieveTitles(FilterQuery filterQuery, String searchType, String packageIds,
+                                                  Sort sort, int page, int count) {
     String query = new TitlesFilterableUrlBuilder()
       .filter(filterQuery)
       .searchType(searchType)
+      .packageIds(packageIds)
       .sort(sort)
       .page(page)
       .count(count)

--- a/src/main/java/org/folio/holdingsiq/service/impl/urlbuilder/TitlesFilterableUrlBuilder.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/urlbuilder/TitlesFilterableUrlBuilder.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.defaultString;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.folio.holdingsiq.model.FilterQuery;
 import org.folio.holdingsiq.model.Sort;
@@ -24,6 +25,7 @@ public class TitlesFilterableUrlBuilder {
   private int count = 25;
   private Sort sort;
   private String searchType;
+  private String packageIds;
 
   public TitlesFilterableUrlBuilder filter(FilterQuery filterQuery) {
     this.filterQuery = filterQuery;
@@ -32,6 +34,11 @@ public class TitlesFilterableUrlBuilder {
 
   public TitlesFilterableUrlBuilder searchType(String searchType) {
     this.searchType = searchType;
+    return this;
+  }
+
+  public TitlesFilterableUrlBuilder packageIds(String packageIds) {
+    this.packageIds = packageIds;
     return this;
   }
 
@@ -82,6 +89,7 @@ public class TitlesFilterableUrlBuilder {
     parameters.add("selection=" + defaultString(filterQuery.getSelected(), DEFAULT_SELECTION));
     parameters.add("resourcetype=" + defaultString(filterQuery.getType(), DEFAULT_RESOURCE_TYPE));
     parameters.add("searchtype=" + defaultString(searchType, DEFAULT_SEARCH_TYPE));
+    Optional.ofNullable(packageIds).ifPresent(ids -> parameters.add("packageidfilter=" + ids));
     parameters.add(query);
 
     return String.join("&", parameters);

--- a/src/test/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceTestConfig.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceTestConfig.java
@@ -29,6 +29,7 @@ public class HoldingsIQServiceTestConfig {
   protected static final String STUB_CUSTOMER_ID = "TEST_CUSTOMER_ID";
   protected static final String STUB_API_KEY = "test_key";
   protected static final String STUB_BASE_URL = "https://sandbox.ebsco.io";
+  protected static final String PACKAGE_IDS = "123,23";
   protected static final int PAGE_FOR_PARAM = 1;
   protected static final int COUNT_FOR_PARAM = 5;
   protected static final Long PACKAGE_ID = 2222L;

--- a/src/test/java/org/folio/holdingsiq/service/impl/TitlesHoldingsIQServiceImplTest.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/TitlesHoldingsIQServiceImplTest.java
@@ -32,11 +32,12 @@ public class TitlesHoldingsIQServiceImplTest extends HoldingsIQServiceTestConfig
   public void testRetrieveTitles() {
     var urlPattern = new UrlPattern(equalTo(
       "/rm/rmaccounts/" + STUB_CUSTOMER_ID + "/titles?searchfield=titlename&selection=all&resourcetype=all&searchtype=" +
-        "advanced&search=&offset=1&count=5&orderby=titlename"), false);
+        "advanced&packageidfilter=123,23&search=&offset=1&count=5&orderby=titlename"), false);
     wiremockServer.stubFor(
       get(urlPattern).willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody(Json.encode(titles)))
     );
-    var completableFuture = service.retrieveTitles(filterQuery, null, Sort.NAME, PAGE_FOR_PARAM, COUNT_FOR_PARAM);
+    var completableFuture = service.retrieveTitles(filterQuery, null, PACKAGE_IDS,
+      Sort.NAME, PAGE_FOR_PARAM, COUNT_FOR_PARAM);
 
     assertTrue(isCompletedNormally(completableFuture));
     verify(new RequestPatternBuilder(RequestMethod.GET, urlPattern));


### PR DESCRIPTION
## Purpose
Extend GET /eholdings/titles response with Facets and add new packageidfilter filter

## Approach
Created new Facets models and added packageidfilter filter with coma-separated IDs content.