### PR TITLE
feat: change long type to int in endpoints/model

### DIFF
--- a/src/main/java/org/folio/holdingsiq/model/PackageCreated.java
+++ b/src/main/java/org/folio/holdingsiq/model/PackageCreated.java
@@ -4,4 +4,4 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record PackageCreated(@JsonProperty("packageId") Long packageId) { }
+public record PackageCreated(@JsonProperty("packageId") Integer packageId) { }

--- a/src/main/java/org/folio/holdingsiq/model/PackageData.java
+++ b/src/main/java/org/folio/holdingsiq/model/PackageData.java
@@ -21,7 +21,7 @@ import lombok.ToString;
 public class PackageData {
 
   @JsonProperty("listId")
-  private Long packageId;
+  private Integer packageId;
 
   @JsonProperty("packageName")
   private String packageName;
@@ -47,7 +47,7 @@ public class PackageData {
   private Boolean isCustom;
 
   @JsonProperty("vendorId")
-  private Long vendorId;
+  private Integer vendorId;
 
   @JsonProperty("vendorName")
   private String vendorName;

--- a/src/main/java/org/folio/holdingsiq/model/PackageId.java
+++ b/src/main/java/org/folio/holdingsiq/model/PackageId.java
@@ -1,6 +1,6 @@
 package org.folio.holdingsiq.model;
 
 public record PackageId(
-  long providerIdPart,
-  long packageIdPart
+  int providerIdPart,
+  int packageIdPart
 ) { }

--- a/src/main/java/org/folio/holdingsiq/model/PackagePut.java
+++ b/src/main/java/org/folio/holdingsiq/model/PackagePut.java
@@ -2,29 +2,57 @@ package org.folio.holdingsiq.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.List;
 import lombok.Builder;
 import lombok.Value;
+import org.folio.holdingsiq.deserializer.AlternateNameListDeserializer;
 
 @Value
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PackagePut {
+
   @JsonProperty("packageName")
-  private String packageName;
+  String packageName;
+
   @JsonProperty(value = "contentType")
-  private Integer contentType;
-  @JsonProperty("customCoverage")
-  private CoverageDates customCoverage;
+  Integer contentType;
+
   @JsonProperty("isSelected")
-  private Boolean isSelected;
+  Boolean isSelected;
+
+  @JsonProperty("visibility")
+  List<Visibility> visibilityDetails;
+
+  @JsonProperty("customDescription")
+  String customDescription;
+
+  @JsonProperty("url")
+  String packageUrl;
+
   @JsonProperty("isFullPackage")
-  private Boolean isFullPackage;
+  Boolean isFullPackage;
+
   @JsonProperty("allowEbscoToAddTitles")
-  private Boolean allowEbscoToAddTitles;
-  @JsonProperty("isHidden")
-  private Boolean isHidden;
-  @JsonProperty("packageToken")
-  private TokenInfo packageToken;
+  Boolean allowEbscoToAddTitles;
+
+  @JsonProperty("customCoverage")
+  CoverageDates customCoverage;
+
   @JsonProperty("proxy")
-  private Proxy proxy;
+  Proxy proxy;
+
+  @JsonProperty("packageToken")
+  TokenInfo packageToken;
+
+  @JsonProperty("customAltNames")
+  @JsonDeserialize(using = AlternateNameListDeserializer.class)
+  List<AlternateName> customAltNames;
+
+  @JsonProperty("customDisplayName")
+  String customDisplayName;
+
+  @JsonProperty("packageFreeAccess")
+  Boolean packageFreeAccess;
 }

--- a/src/main/java/org/folio/holdingsiq/model/ResourceId.java
+++ b/src/main/java/org/folio/holdingsiq/model/ResourceId.java
@@ -1,7 +1,7 @@
 package org.folio.holdingsiq.model;
 
 public record ResourceId(
-  long providerIdPart,
-  long packageIdPart,
-  long titleIdPart
+  int providerIdPart,
+  int packageIdPart,
+  int titleIdPart
 ) { }

--- a/src/main/java/org/folio/holdingsiq/model/SubjectAssociation.java
+++ b/src/main/java/org/folio/holdingsiq/model/SubjectAssociation.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record SubjectAssociation(
-  @JsonProperty("id") Long id,
-  @JsonProperty("schemaId") Long schemaId,
+  @JsonProperty("id") Integer id,
+  @JsonProperty("schemaId") Integer schemaId,
   @JsonProperty("name") String name,
   @JsonProperty("isCustom") Boolean isCustom,
   @JsonProperty("explicitAssignment") Boolean explicitAssignment,

--- a/src/main/java/org/folio/holdingsiq/model/SubjectFacet.java
+++ b/src/main/java/org/folio/holdingsiq/model/SubjectFacet.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record SubjectFacet(
-  @JsonProperty("id") Long id,
-  @JsonProperty("parentId") Long parentId,
+  @JsonProperty("id") Integer id,
+  @JsonProperty("parentId") Integer parentId,
   @JsonProperty("schema") String subjectSchema,
   @JsonProperty("name") String subjectName,
   @JsonProperty("count") Integer totalCount

--- a/src/main/java/org/folio/holdingsiq/model/TitleCreated.java
+++ b/src/main/java/org/folio/holdingsiq/model/TitleCreated.java
@@ -5,5 +5,5 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record TitleCreated(
-  @JsonProperty("titleId") Long titleId
+  @JsonProperty("titleId") Integer titleId
 ) { }

--- a/src/main/java/org/folio/holdingsiq/model/Vendor.java
+++ b/src/main/java/org/folio/holdingsiq/model/Vendor.java
@@ -17,7 +17,7 @@ import lombok.ToString;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Vendor {
   @JsonProperty("vendorId")
-  private long vendorId;
+  private int vendorId;
   @JsonProperty("vendorName")
   private String vendorName;
   @JsonProperty("packagesTotal")

--- a/src/main/java/org/folio/holdingsiq/service/PackagesHoldingsIQService.java
+++ b/src/main/java/org/folio/holdingsiq/service/PackagesHoldingsIQService.java
@@ -10,15 +10,15 @@ import org.folio.holdingsiq.model.Pageable;
 
 public interface PackagesHoldingsIQService {
 
-  CompletableFuture<PackageData> retrievePackage(long packageId);
+  CompletableFuture<PackageData> retrievePackage(int packageId);
 
   CompletableFuture<Packages> retrievePackages(PackageFilter packageFilter, Pageable pageable);
 
-  CompletableFuture<Packages> retrievePackages(long providerId, PackageFilter packageFilter, Pageable pageable);
+  CompletableFuture<Packages> retrievePackages(int providerId, PackageFilter packageFilter, Pageable pageable);
 
-  CompletableFuture<PackageData> postPackage(PackagePost entity, long providerId);
+  CompletableFuture<PackageData> postPackage(PackagePost entity, int providerId);
 
-  CompletableFuture<Void> updatePackage(long packageId, PackagePut packagePut);
+  CompletableFuture<Void> updatePackage(int packageId, PackagePut packagePut);
 
-  CompletableFuture<Void> deletePackage(long packageId);
+  CompletableFuture<Void> deletePackage(int packageId);
 }

--- a/src/main/java/org/folio/holdingsiq/service/ProviderHoldingsIQService.java
+++ b/src/main/java/org/folio/holdingsiq/service/ProviderHoldingsIQService.java
@@ -9,9 +9,9 @@ import org.folio.holdingsiq.model.Vendors;
 
 public interface ProviderHoldingsIQService {
 
-  CompletableFuture<Long> getVendorId();
-  CompletableFuture<VendorById> retrieveProvider(long id);
+  CompletableFuture<Integer> getVendorId();
+  CompletableFuture<VendorById> retrieveProvider(int id);
   CompletableFuture<Vendors> retrieveProviders(String q, int page, int count, Sort sort);
-  CompletableFuture<VendorById> updateProvider(long id, VendorPut vendorPut);
+  CompletableFuture<VendorById> updateProvider(int id, VendorPut vendorPut);
 
 }

--- a/src/main/java/org/folio/holdingsiq/service/TitlesHoldingsIQService.java
+++ b/src/main/java/org/folio/holdingsiq/service/TitlesHoldingsIQService.java
@@ -11,13 +11,13 @@ import org.folio.holdingsiq.model.Titles;
 
 public interface TitlesHoldingsIQService {
 
-  CompletableFuture<Title> retrieveTitle(long titleId);
+  CompletableFuture<Title> retrieveTitle(int titleId);
 
   CompletableFuture<Titles> retrieveTitles(String rmapiQuery);
 
   CompletableFuture<Titles> retrieveTitles(FilterQuery filterQuery, String searchType, Sort sort, int page, int count);
 
-  CompletableFuture<Titles> retrieveTitles(long providerId, long packageId, FilterQuery filterQuery, String searchType,
+  CompletableFuture<Titles> retrieveTitles(int providerId, int packageId, FilterQuery filterQuery, String searchType,
                                            Sort sort, int page, int count);
 
   CompletableFuture<Title> postTitle(TitlePost titlePost, PackageId packageId);

--- a/src/main/java/org/folio/holdingsiq/service/impl/PackagesHoldingsIQServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/PackagesHoldingsIQServiceImpl.java
@@ -28,7 +28,7 @@ public class PackagesHoldingsIQServiceImpl implements PackagesHoldingsIQService 
   }
 
   @Override
-  public CompletableFuture<PackageData> retrievePackage(long packageId) {
+  public CompletableFuture<PackageData> retrievePackage(int packageId) {
     final String path = LISTS_PATH + '/' + packageId;
     return holdingsRequestHelper.getRequest(holdingsRequestHelper.constructURLv2(path), PackageData.class);
   }
@@ -41,27 +41,27 @@ public class PackagesHoldingsIQServiceImpl implements PackagesHoldingsIQService 
   }
 
   @Override
-  public CompletableFuture<Packages> retrievePackages(long providerId, PackageFilter packageFilter, Pageable pageable) {
+  public CompletableFuture<Packages> retrievePackages(int providerId, PackageFilter packageFilter, Pageable pageable) {
     var queryParams = new PackagesFilterableUrlBuilder(packageFilter, pageable).build();
     var url = holdingsRequestHelper.constructURLv2(VENDORS_PATH + '/' + providerId + '/' + LISTS_PATH, queryParams);
     return holdingsRequestHelper.getRequest(url, Packages.class);
   }
 
   @Override
-  public CompletableFuture<PackageData> postPackage(PackagePost entity, long providerId) {
+  public CompletableFuture<PackageData> postPackage(PackagePost entity, int providerId) {
     String path = VENDORS_PATH + '/' + providerId + '/' + PACKAGES_PATH;
     return holdingsRequestHelper.postRequest(holdingsRequestHelper.constructURL(path), entity, PackageCreated.class)
       .thenCompose(packageCreated -> retrievePackage(packageCreated.packageId()));
   }
 
   @Override
-  public CompletableFuture<Void> updatePackage(long packageId, PackagePut packagePut) {
+  public CompletableFuture<Void> updatePackage(int packageId, PackagePut packagePut) {
     final String path = LISTS_PATH + '/' + packageId;
     return holdingsRequestHelper.putRequest(holdingsRequestHelper.constructURLv2(path), packagePut);
   }
 
   @Override
-  public CompletableFuture<Void> deletePackage(long packageId) {
+  public CompletableFuture<Void> deletePackage(int packageId) {
     final String path = LISTS_PATH + '/' + packageId;
     return holdingsRequestHelper.putRequest(holdingsRequestHelper.constructURLv2(path),
       new PackageSelectedPayload(false));

--- a/src/main/java/org/folio/holdingsiq/service/impl/ProviderHoldingsIQServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/ProviderHoldingsIQServiceImpl.java
@@ -37,14 +37,14 @@ public class ProviderHoldingsIQServiceImpl implements ProviderHoldingsIQService 
   }
 
   @Override
-  public CompletableFuture<Long> getVendorId(){
+  public CompletableFuture<Integer> getVendorId(){
     return holdingsIQService.retrieveRootProxyCustomLabels()
       .thenCompose(rootProxyCustomLabels ->
-        CompletableFuture.completedFuture(Long.parseLong(rootProxyCustomLabels.getVendorId())));
+        CompletableFuture.completedFuture(Integer.parseInt(rootProxyCustomLabels.getVendorId())));
   }
 
   @Override
-  public CompletableFuture<VendorById> retrieveProvider(long id) {
+  public CompletableFuture<VendorById> retrieveProvider(int id) {
     CompletableFuture<VendorById> vendorFuture;
     final String path = VENDORS_PATH + '/' + id;
     vendorFuture = holdingsRequestHelper.getRequest(holdingsRequestHelper.constructURL(path), VendorById.class);
@@ -52,7 +52,7 @@ public class ProviderHoldingsIQServiceImpl implements ProviderHoldingsIQService 
   }
 
   @Override
-  public CompletableFuture<VendorById> updateProvider(long id, VendorPut vendorPut) {
+  public CompletableFuture<VendorById> updateProvider(int id, VendorPut vendorPut) {
     final String path = VENDORS_PATH + '/' + id;
 
     return holdingsRequestHelper.putRequest(holdingsRequestHelper.constructURL(path), vendorPut)

--- a/src/main/java/org/folio/holdingsiq/service/impl/TitlesHoldingsIQServiceImpl.java
+++ b/src/main/java/org/folio/holdingsiq/service/impl/TitlesHoldingsIQServiceImpl.java
@@ -32,7 +32,7 @@ public class TitlesHoldingsIQServiceImpl implements TitlesHoldingsIQService {
   }
 
   @Override
-  public CompletableFuture<Title> retrieveTitle(long titleId) {
+  public CompletableFuture<Title> retrieveTitle(int titleId) {
     final String path = TITLES_PATH + '/' + titleId;
     return holdingsRequestHelper.getRequest(holdingsRequestHelper.constructURL(path), Title.class);
   }
@@ -60,7 +60,7 @@ public class TitlesHoldingsIQServiceImpl implements TitlesHoldingsIQService {
   }
 
   @Override
-  public CompletableFuture<Titles> retrieveTitles(long providerId, long packageId, FilterQuery filterQuery,
+  public CompletableFuture<Titles> retrieveTitles(int providerId, int packageId, FilterQuery filterQuery,
                                                   String searchType, Sort sort,
                                                   int page, int count) {
     String query = new TitlesFilterableUrlBuilder()

--- a/src/test/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceTestConfig.java
+++ b/src/test/java/org/folio/holdingsiq/service/impl/HoldingsIQServiceTestConfig.java
@@ -32,9 +32,9 @@ public class HoldingsIQServiceTestConfig {
   protected static final String STUB_BASE_URL = "https://sandbox.ebsco.io";
   protected static final int PAGE_FOR_PARAM = 1;
   protected static final int COUNT_FOR_PARAM = 5;
-  protected static final long PACKAGE_ID = 2222L;
-  protected static final long TITLE_ID = 3333L;
-  protected static final long VENDOR_ID = 5555L;
+  protected static final int PACKAGE_ID = 2222;
+  protected static final int TITLE_ID = 3333;
+  protected static final int VENDOR_ID = 5555;
 
   @RegisterExtension
   public static WireMockExtension wm = WireMockExtension.newInstance().options(WireMockConfiguration.wireMockConfig()


### PR DESCRIPTION
## Purpose
- Change long type to int in endpoints/model for consistency. (HoldingsIQ confirmed they could be only int)
- Update package put model to include new fields.
Related to https://folio-org.atlassian.net/browse/FHIQC-49
